### PR TITLE
feat: 유저 엔티티에 음식, 장난감 수량에 대한 정보 추가

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/User.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/User.kt
@@ -6,6 +6,8 @@ class User(
     val id: String,
     var name: String?,
     var purposeCalorie: Int = 100,
+    var foodQuantity: Int = 0,
+    var toyQuantity: Int = 0,
 ) {
     fun update(
         name: String,

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/UserEntity.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/UserEntity.kt
@@ -24,6 +24,8 @@ data class UserEntity(
             id = id,
             name = name,
             purposeCalorie = purposeCalorie,
+            foodQuantity = foodQuantity,
+            toyQuantity = toyQuantity,
         )
 
     companion object {

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/UserEntity.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/UserEntity.kt
@@ -14,6 +14,10 @@ data class UserEntity(
     val name: String?,
     @Column(name = "purpose_calorie", nullable = false)
     val purposeCalorie: Int,
+    @Column(name = "food_quantity", nullable = false)
+    val foodQuantity: Int,
+    @Column(name = "toy_quantity", nullable = false)
+    val toyQuantity: Int,
 ) : BaseEntity() {
     fun toDomain() =
         User(
@@ -29,6 +33,8 @@ data class UserEntity(
                     id = id,
                     name = name,
                     purposeCalorie = purposeCalorie,
+                    foodQuantity = foodQuantity,
+                    toyQuantity = toyQuantity,
                 )
             }
     }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/UserResponse.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/UserResponse.kt
@@ -10,7 +10,11 @@ data class UserResponse(
     @Schema(description = "User 표기 이름", example = "UserName")
     val name: String?,
     @Schema(description = "User 목표 칼로리", example = "100", minimum = "100", maximum = "1000")
-    var purposeCalorie: Int,
+    val purposeCalorie: Int,
+    @Schema(description = "User 음식 수량", example = "5")
+    val foodQuantity: Int,
+    @Schema(description = "User 장난감 수량", example = "2")
+    val toyQuantity: Int,
 ) {
     companion object {
         fun fromDomain(user: User) =
@@ -19,6 +23,8 @@ data class UserResponse(
                     id = id,
                     name = name,
                     purposeCalorie = purposeCalorie,
+                    foodQuantity = foodQuantity,
+                    toyQuantity = toyQuantity,
                 )
             }
     }


### PR DESCRIPTION
## 🔎 작업 내용
- 유저 엔티티에 펫에게 줄 먹이 수량과 장난감 수량을 저장할 수 있도록 한다. 

## ➕ 기타
- 

close 
