### PR TITLE
feat: 온보딩 여부 로직 변경

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/User.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/User.kt
@@ -38,6 +38,8 @@ class User(
         this.mainPetId = petId
     }
 
+    fun hasMainPet(): Boolean = this.mainPetId != null
+
     companion object {
         fun register(name: String? = null): User = User(id = generateTsid(), name = name)
     }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/auth/LoginOAuth.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/auth/LoginOAuth.kt
@@ -48,7 +48,7 @@ class LoginOAuth(
                 accessToken = tokenGateway.createAccessToken(newUser),
                 refreshToken = tokenGateway.createRefreshToken(newUser),
                 user = newUser,
-                isOnboardingComplete = false,
+                isOnboardingComplete = newUser.hasMainPet(),
             )
         }
         // 가입된 유저의 경우 토큰 발급
@@ -58,7 +58,7 @@ class LoginOAuth(
             accessToken = tokenGateway.createAccessToken(user),
             refreshToken = tokenGateway.createRefreshToken(user),
             user = user,
-            isOnboardingComplete = true,
+            isOnboardingComplete = user.hasMainPet(),
         )
     }
 


### PR DESCRIPTION
## 🔎 작업 내용
- 온보딩 여부를 메인 펫의 존재 유무로 상태를 관리하도록 변경

## ➕ 기타
- 

close #50 
