### PR TITLE
feat: 일일 칼로리 갱신 API에 장난감 제공 기능 추가

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/gateway/DailyInfoGateway.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/gateway/DailyInfoGateway.kt
@@ -10,4 +10,10 @@ interface DailyInfoGateway {
         userId: String,
         date: LocalDate,
     ): DailyInfo
+
+    fun getByDateBeforeNDays(
+        userId: String,
+        date: LocalDate,
+        n: Int,
+    ): List<DailyInfo>
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/DailyInfo.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/DailyInfo.kt
@@ -9,6 +9,8 @@ class DailyInfo(
     val userId: String,
     val date: LocalDate,
     var calorie: Int,
+    var purposeAchieved: Boolean = false,
+    var toyGiven: Boolean = false,
 ) {
     fun update(calorie: Int) {
         this.calorie = max(this.calorie, calorie)

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/UpdateCalorieAndRewardFood.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/UpdateCalorieAndRewardFood.kt
@@ -32,10 +32,34 @@ class UpdateCalorieAndRewardFood(
         val user =
             userGateway.getById(input.userId).apply { foodQuantity += getRewardFood(calorieDailyInfo.calorie, input.calorie) }
 
+        if (isDailyPurposeAchieve(calorieDailyInfo, user, input.calorie)) {
+            calorieDailyInfo.purposeAchieved = true
+            val dailyInfosBefore2Days = dailyInfoGateway.getByDateBeforeNDays(input.userId, input.today, 2)
+            if (validateToyGiven(dailyInfosBefore2Days)) {
+                user.toyQuantity++
+                calorieDailyInfo.toyGiven = true
+            }
+        }
+
         calorieDailyInfo.update(input.calorie)
 
         return Output(userGateway.save(user), dailyInfoGateway.save(calorieDailyInfo))
     }
+
+    private fun validateToyGiven(dailyInfos: List<DailyInfo>): Boolean {
+        if (dailyInfos.size != 2) return false
+        dailyInfos.forEach {
+            if (it.purposeAchieved.not()) return false
+            if (it.toyGiven) return false
+        }
+        return true
+    }
+
+    private fun isDailyPurposeAchieve(
+        calorieDailyInfo: DailyInfo,
+        user: User,
+        currentCalorie: Int,
+    ) = calorieDailyInfo.calorie < user.purposeCalorie && currentCalorie >= user.purposeCalorie
 
     private fun getRewardFood(
         previousCalorie: Int,

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/DailyInfoEntity.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/DailyInfoEntity.kt
@@ -17,6 +17,10 @@ data class DailyInfoEntity(
     val date: LocalDate,
     @Column(name = "calorie", nullable = false)
     val calorie: Int,
+    @Column(name = "purpose_achieved", nullable = false)
+    val purposeAchieved: Boolean = false,
+    @Column(name = "toy_given", nullable = false)
+    val toyGiven: Boolean = false,
 ) : BaseEntity() {
     fun toDomain() =
         DailyInfo(
@@ -24,6 +28,8 @@ data class DailyInfoEntity(
             userId = userId,
             date = date,
             calorie = calorie,
+            purposeAchieved = purposeAchieved,
+            toyGiven = toyGiven,
         )
 
     companion object {
@@ -34,6 +40,8 @@ data class DailyInfoEntity(
                     userId = userId,
                     date = date,
                     calorie = calorie,
+                    purposeAchieved = purposeAchieved,
+                    toyGiven = toyGiven,
                 )
             }
     }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/respository/DailyInfoRepository.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/respository/DailyInfoRepository.kt
@@ -9,4 +9,10 @@ interface DailyInfoRepository : JpaRepository<DailyInfoEntity, String> {
         userId: String,
         date: LocalDate,
     ): DailyInfoEntity?
+
+    fun findByUserIdAndDateBetween(
+        userId: String,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<DailyInfoEntity>
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/gateway/DailyInfoGatewayImpl.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/gateway/DailyInfoGatewayImpl.kt
@@ -21,4 +21,14 @@ class DailyInfoGatewayImpl(
             .findByUserIdAndDate(userId, date)
             ?.toDomain()
             ?: DailyInfo.register(userId, date, calorie = 0)
+
+    override fun getByDateBeforeNDays(
+        userId: String,
+        date: LocalDate,
+        n: Int,
+    ): List<DailyInfo> {
+        val endDate = date.minusDays(1)
+        val startDate = date.minusDays(n.toLong())
+        return dailyInfoRepository.findByUserIdAndDateBetween(userId, startDate, endDate).map { it.toDomain() }
+    }
 }


### PR DESCRIPTION
## 🔎 작업 내용
- 일일 칼로리 갱신 API에 조건을 만족하면 장난감을 제공합니다.
  - 조건: 3일 연속 목표 달성


## ➕ 기타
- 

close #47 
