### PR TITLE
feat: APPLE 로그인 추가

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/gateway/OAuthGateway.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/gateway/OAuthGateway.kt
@@ -4,4 +4,6 @@ import notbe.tmtm.ddanddanserver.domain.model.auth.OAuthInfo
 
 interface OAuthGateway {
     fun getOAuthUserInfo(accessToken: String): OAuthInfo
+
+    fun getOAuthUserInfoFromApple(accessToken: String): OAuthInfo
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/auth/OAuthType.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/auth/OAuthType.kt
@@ -2,4 +2,5 @@ package notbe.tmtm.ddanddanserver.domain.model.auth
 
 enum class OAuthType {
     KAKAO,
+    APPLE,
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/auth/LoginOAuth.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/auth/LoginOAuth.kt
@@ -74,7 +74,13 @@ class LoginOAuth(
                     throw OAuthenticationInvalidTokenException(oAuthType)
                 }
             }
-            // TODO: apple login 정보 추가 필요
+            OAuthType.APPLE -> {
+                return try {
+                    oAuthGateway.getOAuthUserInfoFromApple(accessToken)
+                } catch (e: Exception) {
+                    throw OAuthenticationInvalidTokenException(oAuthType)
+                }
+            }
             else -> throw Exception("Not Supported Token Type")
         }
     }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/client/AppleClient.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/client/AppleClient.kt
@@ -1,0 +1,110 @@
+package notbe.tmtm.ddanddanserver.infrastructure.client
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.jsonwebtoken.*
+import notbe.tmtm.ddanddanserver.infrastructure.client.dto.response.AppleOAuthInfoResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.PublicKey
+import java.security.spec.RSAPublicKeySpec
+import java.util.*
+
+
+@Component
+class AppleClient(
+    @Value("\${APPLE_CLIENT_SECRET}") clientSecret: String,
+    @Value("\${APPLE_BUNDLE_ID}") bundleId: String,
+    @Value("\${APPLE_SERVICE_ID}") serviceId: String,
+    @Value("\${APPLE_KEY_ID}") keyId: String,
+    private val restClient: RestClient,
+    private val objectMapper: ObjectMapper,
+) {
+
+    fun getOAuthInfo(token: String): AppleOAuthInfoResponse {
+        val headers = parseHeaders(token)
+        val appleKeys = getAppleKeys()
+        val publicKey = generatePublicKey(headers, appleKeys)
+
+        val claims = parseClaims(token, publicKey)
+        return AppleOAuthInfoResponse(
+            id = claims["sub"].toString(),
+            properties = AppleOAuthInfoResponse.Properties(
+                nickname = claims["email"].toString(),
+            )
+        )
+    }
+
+    private fun parseHeaders(token: String): Map<String, String> {
+        val encodedHeader: String =
+            token.split(TOKEN_VALUE_DELIMITER.toRegex()).dropLastWhile { it.isEmpty() }
+                .toTypedArray()[0]
+        val decodedHeader = String(Base64.getUrlDecoder().decode(encodedHeader))
+        return objectMapper.readValue(
+            decodedHeader,
+            object : TypeReference<Map<String, String>>() {})
+    }
+
+    private fun getAppleKeys(): AppleKeys {
+        return restClient.get()
+            .uri("https://appleid.apple.com/auth/keys")
+            .exchange { _, clientResponse ->
+                clientResponse.bodyTo(AppleKeys::class.java)
+                    ?: throw IllegalStateException("Apple 로그인 과정중 문제 발생. public key를 조회할 수 없음. $clientResponse")
+            }
+    }
+
+    private fun generatePublicKey(
+        tokenHeaders: Map<String, String>,
+        appleKeys: AppleKeys,
+    ): PublicKey {
+        val publicKeys: List<Key> = appleKeys.keys
+        val publicKey: Key = publicKeys.stream()
+            .filter { key -> key.alg == tokenHeaders["alg"] }
+            .filter { key -> key.kid == tokenHeaders["kid"] }
+            .findAny()
+            .orElseThrow()
+
+        return generatePublicKeyWithApplePublicKey(publicKey)
+    }
+
+    private fun generatePublicKeyWithApplePublicKey(applePublicKey: Key): PublicKey {
+        val n = Base64.getDecoder().decode(applePublicKey.n)
+        val e = Base64.getDecoder().decode(applePublicKey.e)
+
+        val publicKeySpec =
+            RSAPublicKeySpec(BigInteger(1, n), BigInteger(1, e))
+
+        val keyFactory: KeyFactory = KeyFactory.getInstance(applePublicKey.kty)
+
+        return keyFactory.generatePublic(publicKeySpec)
+    }
+
+    private fun parseClaims(idToken: String?, publicKey: PublicKey?): Claims {
+        return Jwts.parser()
+            .verifyWith(publicKey)
+            .build()
+            .parseEncryptedClaims(idToken)
+            .payload
+    }
+
+    data class AppleKeys(
+        val keys: List<Key>
+    )
+
+    data class Key(
+        val kty: String,  // Key Type (e.g., "RSA")
+        val kid: String,  // Key ID
+        val use: String,  // Usage (e.g., "sig")
+        val alg: String,  // Algorithm (e.g., "RS256")
+        val n: String,    // Modulus
+        val e: String     // Exponent
+    )
+
+    private companion object {
+        private const val TOKEN_VALUE_DELIMITER = "\\."
+    }
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/client/dto/response/AppleOAuthInfoResponse.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/client/dto/response/AppleOAuthInfoResponse.kt
@@ -1,0 +1,20 @@
+package notbe.tmtm.ddanddanserver.infrastructure.client.dto.response
+
+import notbe.tmtm.ddanddanserver.domain.model.auth.OAuthInfo
+import notbe.tmtm.ddanddanserver.domain.model.auth.OAuthType
+
+data class AppleOAuthInfoResponse(
+    val id: String,
+    val properties: Properties,
+) {
+    data class Properties(
+        val nickname: String?,
+    )
+
+    fun toDomain() =
+        OAuthInfo(
+            id = id,
+            type = OAuthType.APPLE,
+            nickName = properties.nickname,
+        )
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/gateway/OAuthGatewayImpl.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/gateway/OAuthGatewayImpl.kt
@@ -1,12 +1,17 @@
 package notbe.tmtm.ddanddanserver.infrastructure.gateway
 
 import notbe.tmtm.ddanddanserver.domain.gateway.OAuthGateway
+import notbe.tmtm.ddanddanserver.domain.model.auth.OAuthInfo
+import notbe.tmtm.ddanddanserver.infrastructure.client.AppleClient
 import notbe.tmtm.ddanddanserver.infrastructure.client.KakaoClient
 import org.springframework.stereotype.Component
 
 @Component
 class OAuthGatewayImpl(
     private val kakaoClient: KakaoClient,
+    private val appleClient: AppleClient,
 ) : OAuthGateway {
     override fun getOAuthUserInfo(accessToken: String) = kakaoClient.getOAuthInfo(accessToken).toDomain()
+
+    override fun getOAuthUserInfoFromApple(accessToken: String): OAuthInfo = appleClient.getOAuthInfo(accessToken).toDomain()
 }


### PR DESCRIPTION
## 🔎 작업 내용
- APPLE 로그인 추가
- OAuthType에 APPLE추가
- APPLE 로그인 플로우가 아래처럼 되는거같음.
    - 사용자한테 accessToken 받음 <- jwt임
    - apple public key로 token 복호화
    - claims안에 사용자 정보가 담겨 있음. (claims는 아래와 같은듯)
```
{
  "iss": "https://appleid.apple.com",
  "aud": "com.example.app",
  "exp": 1696439412,
  "iat": 1696435812,
  "sub": "001122.33445566778899aa.bbccddeeff",
  "email": "user@example.com",
  "email_verified": "true",
  "nonce": "nonceValueHere",
  "nonce_supported": true,
  "auth_time": 1696435800
}
```

## ➕ 기타
- 

close 
