### PR TITLE
fix: Apple 로그인 Token Decoder를 UrlSafeDecoder로 수정

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/client/AppleClient.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/client/AppleClient.kt
@@ -85,8 +85,8 @@ class AppleClient(
     }
 
     private fun generatePublicKeyWithApplePublicKey(applePublicKey: Key): PublicKey {
-        val n = Base64.getDecoder().decode(applePublicKey.n)
-        val e = Base64.getDecoder().decode(applePublicKey.e)
+        val n = Base64.getUrlDecoder().decode(applePublicKey.n)
+        val e = Base64.getUrlDecoder().decode(applePublicKey.e)
 
         val publicKeySpec =
             RSAPublicKeySpec(BigInteger(1, n), BigInteger(1, e))


### PR DESCRIPTION
## 🔎 작업 내용
- Apple 로그인이 안되는 버그를 수정했습니다.

## ➕ 기타
- 

close 
