### PR TITLE
feat: add user setting(app push)

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/gateway/DailyInfoGateway.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/gateway/DailyInfoGateway.kt
@@ -1,6 +1,6 @@
 package notbe.tmtm.ddanddanserver.domain.gateway
 
-import notbe.tmtm.ddanddanserver.domain.model.DailyInfo
+import notbe.tmtm.ddanddanserver.domain.model.user.DailyInfo
 import java.time.LocalDate
 
 interface DailyInfoGateway {

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/gateway/TokenGateway.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/gateway/TokenGateway.kt
@@ -1,6 +1,6 @@
 package notbe.tmtm.ddanddanserver.domain.gateway
 
-import notbe.tmtm.ddanddanserver.domain.model.User
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 
 interface TokenGateway {
     fun createAccessToken(user: User): String

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/gateway/UserGateway.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/gateway/UserGateway.kt
@@ -1,6 +1,6 @@
 package notbe.tmtm.ddanddanserver.domain.gateway
 
-import notbe.tmtm.ddanddanserver.domain.model.User
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 
 interface UserGateway {
     fun save(user: User): User

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/user/DailyInfo.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/user/DailyInfo.kt
@@ -1,4 +1,4 @@
-package notbe.tmtm.ddanddanserver.domain.model
+package notbe.tmtm.ddanddanserver.domain.model.user
 
 import notbe.tmtm.ddanddanserver.common.util.generateObjectId
 import notbe.tmtm.ddanddanserver.domain.model.pet.PetType

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/user/User.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/user/User.kt
@@ -1,4 +1,4 @@
-package notbe.tmtm.ddanddanserver.domain.model
+package notbe.tmtm.ddanddanserver.domain.model.user
 
 import notbe.tmtm.ddanddanserver.common.util.generateObjectId
 import notbe.tmtm.ddanddanserver.domain.exception.UserFoodQuantityLackException
@@ -12,6 +12,7 @@ class User(
     var purposeCalorie: Int = 100,
     var foodQuantity: Int = 0,
     var toyQuantity: Int = 0,
+    var setting: UserSetting = UserSetting(),
 ) {
     fun feed(quantity: Int = 1) {
         if (this.foodQuantity < quantity) {

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/user/UserSetting.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/user/UserSetting.kt
@@ -1,0 +1,5 @@
+package notbe.tmtm.ddanddanserver.domain.model.user
+
+data class UserSetting(
+    val isAppPushOn: Boolean = false,
+)

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/auth/LoginOAuth.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/auth/LoginOAuth.kt
@@ -6,10 +6,10 @@ import notbe.tmtm.ddanddanserver.domain.gateway.AuthGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.OAuthGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.TokenGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
-import notbe.tmtm.ddanddanserver.domain.model.User
 import notbe.tmtm.ddanddanserver.domain.model.auth.Auth
 import notbe.tmtm.ddanddanserver.domain.model.auth.OAuthInfo
 import notbe.tmtm.ddanddanserver.domain.model.auth.OAuthType
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.domain.usecase.UseCase
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/auth/ReissueToken.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/auth/ReissueToken.kt
@@ -2,7 +2,7 @@ package notbe.tmtm.ddanddanserver.domain.usecase.auth
 
 import notbe.tmtm.ddanddanserver.domain.gateway.TokenGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
-import notbe.tmtm.ddanddanserver.domain.model.User
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.domain.usecase.UseCase
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/pet/FeedPet.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/pet/FeedPet.kt
@@ -4,8 +4,8 @@ import notbe.tmtm.ddanddanserver.domain.exception.PetMaxLevelException
 import notbe.tmtm.ddanddanserver.domain.exception.PetOwnerMismatchException
 import notbe.tmtm.ddanddanserver.domain.gateway.PetGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
-import notbe.tmtm.ddanddanserver.domain.model.User
 import notbe.tmtm.ddanddanserver.domain.model.pet.Pet
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.domain.usecase.UseCase
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/pet/PlayPet.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/pet/PlayPet.kt
@@ -4,8 +4,8 @@ import notbe.tmtm.ddanddanserver.domain.exception.PetMaxLevelException
 import notbe.tmtm.ddanddanserver.domain.exception.PetOwnerMismatchException
 import notbe.tmtm.ddanddanserver.domain.gateway.PetGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
-import notbe.tmtm.ddanddanserver.domain.model.User
 import notbe.tmtm.ddanddanserver.domain.model.pet.Pet
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.domain.usecase.UseCase
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/GetUser.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/GetUser.kt
@@ -1,7 +1,7 @@
 package notbe.tmtm.ddanddanserver.domain.usecase.user
 
 import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
-import notbe.tmtm.ddanddanserver.domain.model.User
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.domain.usecase.UseCase
 import notbe.tmtm.ddanddanserver.domain.usecase.user.GetUser.GetUserInput
 import notbe.tmtm.ddanddanserver.domain.usecase.user.GetUser.GetUserOutput

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/SetMainPet.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/SetMainPet.kt
@@ -4,8 +4,8 @@ import notbe.tmtm.ddanddanserver.domain.exception.PetOwnerMismatchException
 import notbe.tmtm.ddanddanserver.domain.gateway.DailyInfoGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.PetGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
-import notbe.tmtm.ddanddanserver.domain.model.User
 import notbe.tmtm.ddanddanserver.domain.model.pet.Pet
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.domain.usecase.UseCase
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/UpdateCalorieAndRewardFood.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/UpdateCalorieAndRewardFood.kt
@@ -3,8 +3,8 @@ package notbe.tmtm.ddanddanserver.domain.usecase.user
 import notbe.tmtm.ddanddanserver.domain.gateway.DailyInfoGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.PetGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
-import notbe.tmtm.ddanddanserver.domain.model.DailyInfo
-import notbe.tmtm.ddanddanserver.domain.model.User
+import notbe.tmtm.ddanddanserver.domain.model.user.DailyInfo
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.domain.usecase.UseCase
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/UpdateUser.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/UpdateUser.kt
@@ -2,7 +2,7 @@ package notbe.tmtm.ddanddanserver.domain.usecase.user
 
 import notbe.tmtm.ddanddanserver.domain.gateway.DailyInfoGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
-import notbe.tmtm.ddanddanserver.domain.model.User
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.domain.usecase.UseCase
 import notbe.tmtm.ddanddanserver.domain.usecase.user.UpdateUser.UpdateUserInput
 import notbe.tmtm.ddanddanserver.domain.usecase.user.UpdateUser.UpdateUserOutput

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/UpdateUserSetting.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/UpdateUserSetting.kt
@@ -1,0 +1,32 @@
+package notbe.tmtm.ddanddanserver.domain.usecase.user
+
+import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
+import notbe.tmtm.ddanddanserver.domain.model.user.UserSetting
+import notbe.tmtm.ddanddanserver.domain.usecase.UseCase
+import notbe.tmtm.ddanddanserver.domain.usecase.user.UpdateUserSetting.Input
+import notbe.tmtm.ddanddanserver.domain.usecase.user.UpdateUserSetting.Output
+import org.springframework.stereotype.Component
+
+@Component
+class UpdateUserSetting(
+    private val userGateway: UserGateway,
+) : UseCase<Input, Output> {
+    data class Input(
+        val userId: String,
+        val isAppPushOn: Boolean?,
+    )
+
+    data class Output(
+        val userSetting: UserSetting,
+    )
+
+    override fun execute(input: Input): Output {
+        val user = userGateway.getById(input.userId)
+        user.setting =
+            user.setting.copy(
+                isAppPushOn = input.isAppPushOn ?: user.setting.isAppPushOn,
+            )
+
+        return Output(userGateway.update(user).setting)
+    }
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/DailyInfoEntity.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/DailyInfoEntity.kt
@@ -1,7 +1,7 @@
 package notbe.tmtm.ddanddanserver.infrastructure.database.entity
 
-import notbe.tmtm.ddanddanserver.domain.model.DailyInfo
 import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
+import notbe.tmtm.ddanddanserver.domain.model.user.DailyInfo
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.LocalDate

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/UserEntity.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/UserEntity.kt
@@ -1,6 +1,7 @@
 package notbe.tmtm.ddanddanserver.infrastructure.database.entity
 
-import notbe.tmtm.ddanddanserver.domain.model.User
+import notbe.tmtm.ddanddanserver.domain.model.user.User
+import notbe.tmtm.ddanddanserver.domain.model.user.UserSetting
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 
@@ -14,6 +15,7 @@ data class UserEntity(
     val purposeCalorie: Int,
     val foodQuantity: Int,
     val toyQuantity: Int,
+    val setting: UserSetting = UserSetting(),
 ) {
     fun toDomain() =
         User(
@@ -24,6 +26,7 @@ data class UserEntity(
             purposeCalorie = purposeCalorie,
             foodQuantity = foodQuantity,
             toyQuantity = toyQuantity,
+            setting = setting,
         )
 
     companion object {
@@ -37,6 +40,7 @@ data class UserEntity(
                     purposeCalorie = purposeCalorie,
                     foodQuantity = foodQuantity,
                     toyQuantity = toyQuantity,
+                    setting = setting,
                 )
             }
     }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/gateway/DailyInfoGatewayImpl.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/gateway/DailyInfoGatewayImpl.kt
@@ -1,7 +1,7 @@
 package notbe.tmtm.ddanddanserver.infrastructure.gateway
 
 import notbe.tmtm.ddanddanserver.domain.gateway.DailyInfoGateway
-import notbe.tmtm.ddanddanserver.domain.model.DailyInfo
+import notbe.tmtm.ddanddanserver.domain.model.user.DailyInfo
 import notbe.tmtm.ddanddanserver.infrastructure.database.entity.DailyInfoEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.DailyInfoRepository
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/gateway/TokenGatewayImpl.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/gateway/TokenGatewayImpl.kt
@@ -1,7 +1,7 @@
 package notbe.tmtm.ddanddanserver.infrastructure.gateway
 
 import notbe.tmtm.ddanddanserver.domain.gateway.TokenGateway
-import notbe.tmtm.ddanddanserver.domain.model.User
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.infrastructure.token.JWTTokenProvider
 import org.springframework.stereotype.Component
 

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/gateway/UserGatewayImpl.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/gateway/UserGatewayImpl.kt
@@ -1,7 +1,7 @@
 package notbe.tmtm.ddanddanserver.infrastructure.gateway
 
 import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
-import notbe.tmtm.ddanddanserver.domain.model.User
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.infrastructure.database.entity.UserEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserRepository
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/token/JWTTokenProvider.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/token/JWTTokenProvider.kt
@@ -7,7 +7,7 @@ import io.jsonwebtoken.Jwts
 import notbe.tmtm.ddanddanserver.domain.exception.AuthenticationExpiredAccessTokenException
 import notbe.tmtm.ddanddanserver.domain.exception.AuthenticationExpiredRefreshTokenException
 import notbe.tmtm.ddanddanserver.domain.exception.AuthenticationInvalidTokenException
-import notbe.tmtm.ddanddanserver.domain.model.User
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/UserSettingController.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/UserSettingController.kt
@@ -1,0 +1,35 @@
+package notbe.tmtm.ddanddanserver.presentation.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import notbe.tmtm.ddanddanserver.domain.usecase.user.UpdateUserSetting
+import notbe.tmtm.ddanddanserver.presentation.dto.request.UserSettingRequest
+import notbe.tmtm.ddanddanserver.presentation.dto.response.UserSettingResponse
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/users/me/settings")
+@Tag(name = "유저 설정")
+class UserSettingController(
+    private val updateUserSetting: UpdateUserSetting,
+) {
+    @PatchMapping
+    @Operation(summary = "유저 설정 수정", description = "유저 설정을 수정합니다.")
+    fun updateUserSetting(
+        authentication: Authentication,
+        @RequestBody request: UserSettingRequest,
+    ): UserSettingResponse {
+        val result =
+            updateUserSetting.execute(
+                UpdateUserSetting.Input(
+                    userId = authentication.name,
+                    isAppPushOn = request.isAppPushOn,
+                ),
+            )
+        return UserSettingResponse.fromDomain(result.userSetting)
+    }
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/request/UserSettingRequest.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/request/UserSettingRequest.kt
@@ -1,0 +1,13 @@
+package notbe.tmtm.ddanddanserver.presentation.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "UserSetting 요청 DTO")
+data class UserSettingRequest(
+    @Schema(description = "앱 푸시 여부", example = "true")
+    val isAppPushOn: Boolean?,
+) {
+    init {
+        requireNotNull(isAppPushOn)
+    }
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/DailyInfoResponse.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/DailyInfoResponse.kt
@@ -1,7 +1,7 @@
 package notbe.tmtm.ddanddanserver.presentation.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import notbe.tmtm.ddanddanserver.domain.model.DailyInfo
+import notbe.tmtm.ddanddanserver.domain.model.user.DailyInfo
 import java.time.LocalDate
 
 @Schema(description = "일일 정보 응답 DTO")

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/LoginResponse.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/LoginResponse.kt
@@ -1,7 +1,7 @@
 package notbe.tmtm.ddanddanserver.presentation.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import notbe.tmtm.ddanddanserver.domain.model.User
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 
 @Schema(description = "로그인 응답 DTO")
 data class LoginResponse(

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/UserDailyInfoResponse.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/UserDailyInfoResponse.kt
@@ -1,8 +1,8 @@
 package notbe.tmtm.ddanddanserver.presentation.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import notbe.tmtm.ddanddanserver.domain.model.DailyInfo
-import notbe.tmtm.ddanddanserver.domain.model.User
+import notbe.tmtm.ddanddanserver.domain.model.user.DailyInfo
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 
 @Schema(description = "User & DailyInfo 응답 DTO")
 data class UserDailyInfoResponse(

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/UserPetResponse.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/UserPetResponse.kt
@@ -1,8 +1,8 @@
 package notbe.tmtm.ddanddanserver.presentation.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import notbe.tmtm.ddanddanserver.domain.model.User
 import notbe.tmtm.ddanddanserver.domain.model.pet.Pet
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 
 @Schema(description = "유저 & 펫 응답 DTO")
 data class UserPetResponse(

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/UserResponse.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/UserResponse.kt
@@ -1,7 +1,7 @@
 package notbe.tmtm.ddanddanserver.presentation.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import notbe.tmtm.ddanddanserver.domain.model.User
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 
 @Schema(description = "User 응답 DTO")
 data class UserResponse(
@@ -15,6 +15,8 @@ data class UserResponse(
     val foodQuantity: Int,
     @Schema(description = "User 장난감 수량", example = "2")
     val toyQuantity: Int,
+    @Schema(description = "User 설정 정보")
+    val setting: UserSettingResponse,
 ) {
     companion object {
         fun fromDomain(user: User) =
@@ -25,6 +27,7 @@ data class UserResponse(
                     purposeCalorie = purposeCalorie,
                     foodQuantity = foodQuantity,
                     toyQuantity = toyQuantity,
+                    setting = UserSettingResponse.fromDomain(setting),
                 )
             }
     }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/UserSettingResponse.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/UserSettingResponse.kt
@@ -1,0 +1,19 @@
+package notbe.tmtm.ddanddanserver.presentation.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import notbe.tmtm.ddanddanserver.domain.model.user.UserSetting
+
+@Schema(description = "UserSetting 응답 DTO")
+data class UserSettingResponse(
+    @Schema(description = "앱 푸시 여부", example = "true")
+    val isAppPushOn: Boolean,
+) {
+    companion object {
+        fun fromDomain(userSetting: UserSetting) =
+            with(userSetting) {
+                UserSettingResponse(
+                    isAppPushOn = isAppPushOn,
+                )
+            }
+    }
+}

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/pet/FeedPetTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/pet/FeedPetTest.kt
@@ -7,9 +7,9 @@ import notbe.tmtm.ddanddanserver.domain.exception.PetOwnerMismatchException
 import notbe.tmtm.ddanddanserver.domain.exception.UserFoodQuantityLackException
 import notbe.tmtm.ddanddanserver.domain.gateway.PetGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
-import notbe.tmtm.ddanddanserver.domain.model.User
 import notbe.tmtm.ddanddanserver.domain.model.pet.Pet
 import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/pet/PlayPetTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/pet/PlayPetTest.kt
@@ -7,9 +7,9 @@ import notbe.tmtm.ddanddanserver.domain.exception.PetOwnerMismatchException
 import notbe.tmtm.ddanddanserver.domain.exception.UserToyQuantityLackException
 import notbe.tmtm.ddanddanserver.domain.gateway.PetGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
-import notbe.tmtm.ddanddanserver.domain.model.User
 import notbe.tmtm.ddanddanserver.domain.model.pet.Pet
 import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/GetUserTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/GetUserTest.kt
@@ -3,7 +3,7 @@ package notbe.tmtm.ddanddanserver.domain.usecase.user
 import io.mockk.every
 import io.mockk.mockk
 import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
-import notbe.tmtm.ddanddanserver.domain.model.User
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import kotlin.test.Test

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/UpdateCalorieAndRewardFoodTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/UpdateCalorieAndRewardFoodTest.kt
@@ -5,9 +5,9 @@ import io.mockk.mockk
 import notbe.tmtm.ddanddanserver.domain.gateway.DailyInfoGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.PetGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
-import notbe.tmtm.ddanddanserver.domain.model.DailyInfo
-import notbe.tmtm.ddanddanserver.domain.model.User
 import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
+import notbe.tmtm.ddanddanserver.domain.model.user.DailyInfo
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/UpdateUserTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/UpdateUserTest.kt
@@ -4,7 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import notbe.tmtm.ddanddanserver.domain.gateway.DailyInfoGateway
 import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
-import notbe.tmtm.ddanddanserver.domain.model.User
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import kotlin.test.Test


### PR DESCRIPTION
## 🔎 작업 내용
This pull request includes changes to reorganize the `User` and `DailyInfo` models into a new `user` package and introduces a new `UserSetting` model. The most important changes include updating the import paths across various files, adding a new `UserSetting` model, and modifying the `User` and `UserEntity` classes to include the new `UserSetting` attribute.

Reorganization of models:

* `src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/DailyInfo.kt` renamed to `src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/user/DailyInfo.kt` and updated the package declaration accordingly.
* `src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/User.kt` renamed to `src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/user/User.kt` and updated the package declaration accordingly.

Introduction of `UserSetting` model:

* Added new file `src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/user/UserSetting.kt` to define the `UserSetting` data class.
* Updated the `User` class to include a new `setting` attribute of type `UserSetting`.

Updates to import paths:

* Updated import paths in various files to reflect the new location of `User` and `DailyInfo` models within the `user` package. [[1]](diffhunk://#diff-6664594168cb658b55b8aced3e5a7b978a5ab934cdb33060268c844dccf24248L3-R3) [[2]](diffhunk://#diff-c0a7927af545497cff09abab1818be9712c53448df0c0e65e636830f3b8089bbL3-R3) [[3]](diffhunk://#diff-aade2da106b865a7ec14daf28a985079446af8992115dab461cfdd463ae39ba1L3-R3) [[4]](diffhunk://#diff-49461ada7d08c09b2643cad3627af3a14ceadc32f714c9dc8bab2990af5cd2f7L9-R12) [[5]](diffhunk://#diff-b35486378638209a8f788df10de1385110748b6760e3e62e55836eb70020c290L5-R5) [[6]](diffhunk://#diff-0682d8e6d275456e63a3309796bef3167ce1c5c04d2a81149871961da07ce3dfL7-R8) [[7]](diffhunk://#diff-2f9994c4341e6d0f57426d6211bb8f49246a304e1134dfaa9b7384a593aee2b8L7-R8) [[8]](diffhunk://#diff-c34850bbe070533f89905c8bc84274844150c283147d92c095681894f13ae4f0L4-R4) [[9]](diffhunk://#diff-b8b24d7e521ec72696b4091741321bd746547d7326001be062f3f049dc78a5e1L7-R8) [[10]](diffhunk://#diff-9f252025cc2f38f4d3d026c5485939e7d776a35d7a78ae9fbfeb94225e029edeL5-R5) [[11]](diffhunk://#diff-0214098ebb29890cc52ce71ebf00711ce4ab7270c401a898f9ec519b18d41a5bL3-R4) [[12]](diffhunk://#diff-e9e1769f89a28cd38b33ca7ab31b3c9b8fa23fc1616636954b1c91fdfe780f7dL4-R4) [[13]](diffhunk://#diff-ab206d04698e0a319abf779407cd20854f6032e6b87470bd621769edf89b7ea0L4-R4)

Enhancements to `UserEntity`:

* Updated the `UserEntity` class to include the new `setting` attribute and adjusted the `toDomain` and `fromDomain` methods accordingly. [[1]](diffhunk://#diff-a858a0c7677091c0a975dacf980f245356bbf154ecac043a2269c54a1a1f3dbfR18) [[2]](diffhunk://#diff-a858a0c7677091c0a975dacf980f245356bbf154ecac043a2269c54a1a1f3dbfR29) [[3]](diffhunk://#diff-a858a0c7677091c0a975dacf980f245356bbf154ecac043a2269c54a1a1f3dbfR43)

New use case for updating user settings:

* Added a new use case `UpdateUserSetting` to handle updates to the `UserSetting` model.

## ➕ 기타
- 

close #113 
