### PR TITLE
refactor: interface impl parameter 이름 일치화

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/gateway/PushGateway.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/gateway/PushGateway.kt
@@ -2,12 +2,12 @@ package notbe.tmtm.ddanddanserver.domain.gateway
 
 interface PushGateway {
     fun send(
-        token: String,
+        deviceToken: String,
         content: String,
     )
 
     fun sendAll(
-        tokens: List<String>,
+        deviceTokens: List<String>,
         content: String,
     )
 }


### PR DESCRIPTION
## 🔎 작업 내용
This pull request includes a small but important change to the `PushGateway` interface in the `src/main/kotlin/notbe/tmtm/ddanddanserver/domain/gateway/PushGateway.kt` file. The change improves the clarity of parameter names.

* [`src/main/kotlin/notbe/tmtm/ddanddanserver/domain/gateway/PushGateway.kt`](diffhunk://#diff-c408144b462ec68beb12c61d42ec1d0004288ffb1d2d57e7c4edfd468bb1804dL5-R10): Renamed parameters `token` to `deviceToken` and `tokens` to `deviceTokens` for better clarity.

## ➕ 기타
- 

close #115 
