### PR TITLE
feat: 유저 랭킹 정보가 없을 때 핸들링

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/exception/ErrorCode.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/exception/ErrorCode.kt
@@ -52,4 +52,10 @@ enum class ErrorCode(
     PET_NOT_FOUND("PE001", "펫을 찾을 수 없습니다."),
     PET_OWNER_MISMATCH("PE002", "펫의 소유자가 일치하지 않습니다."),
     PET_MAX_LEVEL("PE003", "펫이 최대 레벨입니다."),
+
+    /**
+     * 랭킹 오류
+     * @see notbe.tmtm.ddanddanserver.domain.exception.RankingException
+     */
+    NOT_FOUND_USER_STAT("RA001", "유저의 랭킹 정보를 찾을 수 없습니다."),
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/exception/RankingException.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/exception/RankingException.kt
@@ -1,0 +1,10 @@
+package notbe.tmtm.ddanddanserver.domain.exception
+
+open class RankingException(
+    errorCode: ErrorCode,
+    data: Any? = null,
+) : CustomException(errorCode, data)
+
+class NotFoundUserStatException(
+    data: Any? = null,
+) : RankingException(ErrorCode.NOT_FOUND_USER_STAT, data)

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/ranking/GetRanking.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/ranking/GetRanking.kt
@@ -1,5 +1,6 @@
 package notbe.tmtm.ddanddanserver.domain.usecase.ranking
 
+import notbe.tmtm.ddanddanserver.domain.exception.NotFoundUserStatException
 import notbe.tmtm.ddanddanserver.domain.gateway.UserStatGateway
 import notbe.tmtm.ddanddanserver.domain.model.ranking.PeriodType
 import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingCriteria
@@ -51,7 +52,7 @@ class GetRanking(
         userStats: List<Pair<UserStat, Int>>,
         userId: String,
     ): Pair<UserStat, Int> {
-        val myStats = userStats.find { it.first.userId == userId }!!
+        val myStats = userStats.find { it.first.userId == userId } ?: throw NotFoundUserStatException("갱신하지 않은 사용자입니다. userId=$userId")
         return myStats
     }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/config/WebExceptionHandler.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/config/WebExceptionHandler.kt
@@ -9,6 +9,7 @@ import notbe.tmtm.ddanddanserver.domain.exception.CustomException
 import notbe.tmtm.ddanddanserver.domain.exception.ErrorCode
 import notbe.tmtm.ddanddanserver.domain.exception.PermissionDeniedException
 import notbe.tmtm.ddanddanserver.presentation.dto.response.ErrorResponse
+import org.apache.coyote.Response
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
@@ -93,8 +94,6 @@ class WebExceptionHandler {
     @ExceptionHandler(value = [Exception::class])
     fun handleUnhandledException(
         exception: Throwable,
-        request: HttpServletRequest,
-        bodyCache: ContentCachingRequestWrapper,
     ): ResponseEntity<ErrorResponse> {
         if (exception is IOException) {
             return ResponseEntity
@@ -135,5 +134,12 @@ class WebExceptionHandler {
             )
 
     @ExceptionHandler(value = [AccessDeniedException::class])
-    fun handleAccessDeniedException() = (PermissionDeniedException())
+    fun handleAccessDeniedException(exception: AccessDeniedException): ResponseEntity<ErrorResponse> =
+        ResponseEntity
+            .status(HttpStatus.FORBIDDEN)
+            .body(
+                ErrorResponse.fromErrorCode(
+                    errorCode = ErrorCode.PERMISSION_DENIED,
+                ),
+            )
 }


### PR DESCRIPTION
## 🔎 작업 내용
- 기존에 유저 정보를 not null로 매핑했는데, 예외를 던지도록 변경
- 500으로 내려야할 에러 핸들링에서 200 ok가 나오던 버그 수정

## ➕ 기타
- 

close #120 
