### PR TITLE
feat: 몽고디비 타임존 세팅 & 컨버터 셋업

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,7 @@ jib {
         creationTime = "USE_CURRENT_TIMESTAMP"
         ports = listOf("8080")
         user = "1000:1000"
+        jvmFlags = listOf("-Duser.timezone=Asia/Seoul")
     }
 }
 

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/config/MongoConfig.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/config/MongoConfig.kt
@@ -1,5 +1,9 @@
 package notbe.tmtm.ddanddanserver.infrastructure.config
 
+import notbe.tmtm.ddanddanserver.infrastructure.config.converter.DateToLocalDateConverter
+import notbe.tmtm.ddanddanserver.infrastructure.config.converter.DateToLocalDateTimeConverter
+import notbe.tmtm.ddanddanserver.infrastructure.config.converter.LocalDateTimeToDateConverter
+import notbe.tmtm.ddanddanserver.infrastructure.config.converter.LocalDateToDateConverter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.mongodb.MongoDatabaseFactory
@@ -7,6 +11,7 @@ import org.springframework.data.mongodb.config.EnableMongoAuditing
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver
 import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext
 
 @Configuration
@@ -16,7 +21,21 @@ class MongoConfig {
     fun mappingMongoConverter(
         factory: MongoDatabaseFactory,
         context: MongoMappingContext,
+        kstLocalDateTimeWriterConverter: LocalDateTimeToDateConverter,
+        kstDateTimeReaderConverter: DateToLocalDateConverter,
+        kstLocalDateTimeReaderConverter: DateToLocalDateTimeConverter,
+        kstDateTimeWriterConverter: LocalDateToDateConverter,
     ) = MappingMongoConverter(DefaultDbRefResolver(factory), context).apply {
         setTypeMapper(DefaultMongoTypeMapper(null))
+        customConversions =
+            MongoCustomConversions(
+                listOf(
+                    kstLocalDateTimeWriterConverter,
+                    kstLocalDateTimeReaderConverter,
+                    kstDateTimeWriterConverter,
+                    kstDateTimeReaderConverter,
+                ),
+            )
+        afterPropertiesSet()
     }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/config/converter/MongoConverter.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/config/converter/MongoConverter.kt
@@ -1,0 +1,53 @@
+package notbe.tmtm.ddanddanserver.infrastructure.config.converter
+
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.convert.ReadingConverter
+import org.springframework.data.convert.WritingConverter
+import org.springframework.stereotype.Component
+import java.sql.Timestamp
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.Date
+
+@Component
+@WritingConverter
+class LocalDateTimeToDateConverter : Converter<LocalDateTime, Date> {
+    override fun convert(source: LocalDateTime): Date = convertToKst(source)
+
+    private fun convertToKst(localDateTime: LocalDateTime): Date = Timestamp.valueOf(localDateTime.plusHours(9))
+}
+
+@Component
+@WritingConverter
+class LocalDateToDateConverter : Converter<LocalDate, Date> {
+    override fun convert(source: LocalDate): Date = convertToKst(source)
+
+    private fun convertToKst(localDate: LocalDate): Date {
+        val localDateTime = localDate.atStartOfDay().plusHours(9)
+        return Timestamp.valueOf(localDateTime)
+    }
+}
+
+@Component
+@ReadingConverter
+class DateToLocalDateTimeConverter : Converter<Date, LocalDateTime> {
+    override fun convert(source: Date): LocalDateTime = convertToKst(source)
+
+    private fun convertToKst(date: Date): LocalDateTime {
+        val localDateTime = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
+
+        return localDateTime.minusHours(9)
+    }
+}
+
+@Component
+@ReadingConverter
+class DateToLocalDateConverter : Converter<Date, LocalDate> {
+    override fun convert(source: Date): LocalDate = convertToKst(source)
+
+    private fun convertToKst(date: Date): LocalDate {
+        val localDateTime = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
+        return localDateTime.minusHours(9).toLocalDate()
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
- 기존에 타임존 설정이 UTC로 되어있던 걸  KTC로 변경
- 몽고디비 컬렉션들은 Date 타입을 UTC 형태로 변환해서 문제가 발생하지 않았는데, KTC로 변경하면 mongo -> spring 으로 데이터를 꺼내올때 시간이 맞지 않게됨. 이를 문제없이 유지하기 위해 mongoDb에 저장된 데이터를 마이그레이션하지 않고, KTC로 인지할 수 있도록 변경

## ➕ 기타
- 

close 
