### PR TITLE
feat: 일일 칼로리 정보를 영속화 먼저 하도록 변경

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/UpdateCalorieAndRewardFood.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/user/UpdateCalorieAndRewardFood.kt
@@ -6,7 +6,9 @@ import notbe.tmtm.ddanddanserver.domain.gateway.UserGateway
 import notbe.tmtm.ddanddanserver.domain.model.user.DailyInfo
 import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.domain.usecase.UseCase
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.DailyInfoRepository
 import org.bson.types.ObjectId
+import org.springframework.dao.DuplicateKeyException
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -19,6 +21,7 @@ class UpdateCalorieAndRewardFood(
     private val userGateway: UserGateway,
     private val petGateway: PetGateway,
     private val dailyInfoGateway: DailyInfoGateway,
+    private val dailyInfoRepository: DailyInfoRepository,
 ) : UseCase<UpdateCalorieAndRewardFood.Input, UpdateCalorieAndRewardFood.Output> {
     data class Input(
         val userId: ObjectId,
@@ -64,7 +67,11 @@ class UpdateCalorieAndRewardFood(
         dailyInfoGateway.findBy(user.id, today)?.let { return it }
 
         val mainPetType = user.mainPetId?.let { petGateway.getById(it).type }
-        return DailyInfo.create(user.id, user.name, mainPetType, today)
+        return try {
+            dailyInfoRepository.insert(DailyInfo.create(user.id, user.name, mainPetType, today))
+        } catch (e: DuplicateKeyException) {
+            dailyInfoGateway.findBy(user.id, today)!!
+        }
     }
 
     private fun validateToyGiven(dailyInfos: List<DailyInfo>): Boolean {


### PR DESCRIPTION
## 🔎 작업 내용
- findOrCreate에서 find 실패 시 db에 영속화 후 데이터를 처리하도록 변경
- create 과정에서 dup 발생 시 find 하여 처리하도록 변경

## ➕ 기타
- 

close #146 
