### PR TITLE
bug: 중복된 펫 생성 안되도록 수정

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/pet/AddRandomPet.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/usecase/pet/AddRandomPet.kt
@@ -22,7 +22,7 @@ class AddRandomPet(
 
     @Transactional
     override fun execute(input: Input): Output {
-        val pets = petGateway.getAll().map { it.type }.distinct()
+        val pets = petGateway.getPetsByOwnerUserId(input.ownerUserId).map { it.type }.distinct()
         return Output(
             petGateway.save(
                 Pet.register(


### PR DESCRIPTION
## 🔎 작업 내용
- 

## ➕ 기타
- 

close #172 
