### PR TITLE
refactor: #190 Ranking 기능 클린 아키텍처 -> 레이어드 아키텍처로 변경

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/UserRankingService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/UserRankingService.kt
@@ -1,9 +1,14 @@
 package notbe.tmtm.ddanddanserver.application.service
 
 import notbe.tmtm.ddanddanserver.domain.model.ranking.PeriodType
+import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingBoard
 import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingCriteria
 import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingResult
+import notbe.tmtm.ddanddanserver.domain.model.ranking.UserRanking
+import notbe.tmtm.ddanddanserver.domain.model.ranking.UserStat
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserStatRepository
+import notbe.tmtm.ddanddanserver.infrastructure.gateway.RankingBoardAdapter
+import notbe.tmtm.ddanddanserver.infrastructure.gateway.UserStatAdapter
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -11,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class UserRankingService(
     private val userStatRepository: UserStatRepository,
+    private val rankingBoardAdapter: RankingBoardAdapter,
+    private val userStatAdapter: UserStatAdapter,
 ) {
     @Transactional(readOnly = true)
     fun getRanking(
@@ -20,5 +27,24 @@ class UserRankingService(
     ): RankingResult {
         val userStats = userStatRepository.getAllRankingBy(criteria, periodType).map { it.toDomain() }
         return RankingResult.create(userStats, criteria, userId)
+    }
+
+    @Transactional(readOnly = true)
+    fun getRankingBoard(periodType: PeriodType): RankingBoard {
+        return rankingBoardAdapter.getById(periodType)
+    }
+
+    @Transactional(readOnly = true)
+    fun getTopRanking(criteria: RankingCriteria, periodType: PeriodType): UserRanking? {
+        return userStatAdapter.getRanking(criteria, periodType).firstOrNull()?.let { userStat ->
+            UserRanking(userStat, 1)
+        }
+    }
+
+    @Transactional
+    fun updateRankingBoard(periodType: PeriodType): RankingBoard {
+        val userStats = userStatAdapter.getRanking(RankingCriteria.TOTAL_CALORIES, periodType)
+        val rankingBoard = RankingBoard.of(periodType, userStats)
+        return rankingBoardAdapter.save(rankingBoard)
     }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/gateway/RankingBoardAdapter.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/gateway/RankingBoardAdapter.kt
@@ -1,0 +1,21 @@
+package notbe.tmtm.ddanddanserver.infrastructure.gateway
+
+import notbe.tmtm.ddanddanserver.domain.model.ranking.PeriodType
+import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingBoard
+import notbe.tmtm.ddanddanserver.infrastructure.database.entity.RankingBoardEntity
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.RankingBoardRepository
+import org.springframework.stereotype.Component
+import kotlin.jvm.optionals.getOrDefault
+
+@Component
+class RankingBoardAdapter(
+    private val rankingBoardRepository: RankingBoardRepository,
+) {
+    fun save(rankingBoard: RankingBoard) = rankingBoardRepository.save(RankingBoardEntity.fromDomain(rankingBoard)).toDomain()
+
+    fun getById(id: PeriodType) = rankingBoardRepository.findById(id).getOrDefault(RankingBoardEntity(id, emptyList())).toDomain()
+
+    fun update(rankingBoard: RankingBoard) = rankingBoardRepository.save(RankingBoardEntity.fromDomain(rankingBoard)).toDomain()
+
+    fun delete(id: PeriodType) = rankingBoardRepository.deleteById(id)
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/gateway/UserStatAdapter.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/gateway/UserStatAdapter.kt
@@ -1,0 +1,17 @@
+package notbe.tmtm.ddanddanserver.infrastructure.gateway
+
+import notbe.tmtm.ddanddanserver.domain.model.ranking.PeriodType
+import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingCriteria
+import notbe.tmtm.ddanddanserver.domain.model.ranking.UserStat
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserStatRepository
+import org.springframework.stereotype.Component
+
+@Component
+class UserStatAdapter(
+    private val userStatRepository: UserStatRepository,
+) {
+    fun getRanking(
+        criteria: RankingCriteria,
+        periodType: PeriodType,
+    ): List<UserStat> = userStatRepository.getAllRankingBy(criteria, periodType).map { it.toDomain() }
+}

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/UserRankingServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/UserRankingServiceTest.kt
@@ -9,6 +9,8 @@ import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingCriteria
 import notbe.tmtm.ddanddanserver.domain.model.ranking.UserStat
 import notbe.tmtm.ddanddanserver.infrastructure.database.entity.UserStatEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserStatRepository
+import notbe.tmtm.ddanddanserver.infrastructure.gateway.RankingBoardAdapter
+import notbe.tmtm.ddanddanserver.infrastructure.gateway.UserStatAdapter
 import org.bson.types.ObjectId
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -17,12 +19,16 @@ import kotlin.test.assertNotNull
 
 class UserRankingServiceTest {
     private lateinit var userStatRepository: UserStatRepository
+    private lateinit var rankingBoardAdapter: RankingBoardAdapter
+    private lateinit var userStatAdapter: UserStatAdapter
     private lateinit var userRankingService: UserRankingService
 
     @BeforeEach
     fun setUp() {
         userStatRepository = mockk()
-        userRankingService = UserRankingService(userStatRepository)
+        rankingBoardAdapter = mockk<RankingBoardAdapter>()
+        userStatAdapter = mockk<UserStatAdapter>()
+        userRankingService = UserRankingService(userStatRepository, rankingBoardAdapter, userStatAdapter)
     }
 
     @Test


### PR DESCRIPTION
## 🔎 작업 내용
- Ranking 관련 UseCase (`GetRanking`, `GetRankingBoard`, `GetTopRanking`, `UpdateRankingBoard`) 로직을 `UserRankingService`로 통합했습니다.
- `RankingController`에서 UseCase 대신 `UserRankingService`를 직접 호출하도록 수정했습니다.
- `UserRankingService`가 `RankingBoardAdapter`와 `UserStatAdapter`를 직접 의존하도록 수정했습니다.
- `UserRankingServiceTest`를 수정하여 변경된 `UserRankingService`의 의존성을 반영했습니다.

### 연관 이슈
- 리팩토링 전체 계획은 #186 참고
- 본 PR은 #190 이슈를 해결합니다.
