### PR TITLE
feat: Ranking API에 펫레벨 반영

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/NotificationService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/NotificationService.kt
@@ -5,13 +5,23 @@ import com.google.firebase.messaging.Message
 import com.google.firebase.messaging.Notification
 import notbe.tmtm.ddanddanserver.domain.model.notification.PushMessage
 import notbe.tmtm.ddanddanserver.domain.model.notification.RoutingView
+import notbe.tmtm.ddanddanserver.domain.model.ranking.PeriodType
+import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingBoard
+import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingCriteria
+import notbe.tmtm.ddanddanserver.domain.model.ranking.UserStat
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserRepository
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserStatRepository
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.getAllRankingBy
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class NotificationService(
     private val userRepository: UserRepository,
+    private val userStatRepository: UserStatRepository,
+    private val rankingService: RankingService,
     private val fcmClient: FirebaseMessaging,
 ) {
     @Transactional(readOnly = true)
@@ -19,18 +29,8 @@ class NotificationService(
         val allUsers = userRepository.findAll()
             .filter { it.setting.isAppPushOn }
             .filter { it.deviceToken.isNullOrEmpty().not() }
-        
-        sendPushToAllUsers(allUsers.map { it.deviceToken!! }, PushMessage.CHECK_CALORIE.content, RoutingView.MAIN)
-    }
 
-    @Transactional(readOnly = true)
-    fun notifySleepingUsers() {
-        val sleepingUsers = userRepository.findAll()
-            .filter { it.deviceToken.isNullOrEmpty().not() }
-        
-        sleepingUsers.forEach { user ->
-            sendPushToUser(user.deviceToken!!, "잠들어있는 동물을 확인해주세요!", RoutingView.MAIN)
-        }
+        sendPushToAllUsers(allUsers.map { it.deviceToken!! }, PushMessage.CHECK_CALORIE.content, RoutingView.MAIN)
     }
 
     @Transactional(readOnly = true)
@@ -38,29 +38,55 @@ class NotificationService(
         val allUsers = userRepository.findAll()
             .filter { it.setting.isAppPushOn }
             .filter { it.deviceToken.isNullOrEmpty().not() }
-        
+
         sendPushToAllUsers(
             allUsers.map { it.deviceToken!! },
-            "이번 주 1등의 칼로리는 ${totalCalories}칼로리입니다!",
+            "${PushMessage.WEEKLY_RANKING.content} $totalCalories 칼로리를 소모했대요.",
             RoutingView.MAIN
         )
     }
 
     @Transactional(readOnly = true)
     fun notifyRankingDiff() {
-        val allUsers = userRepository.findAll()
-            .filter { it.setting.isAppPushOn }
-            .filter { it.deviceToken.isNullOrEmpty().not() }
-        
-        allUsers.forEach { user ->
-            // 랭킹 차이 계산 로직은 나중에 구현
-            sendPushToUser(user.deviceToken!!, "랭킹이 변동되었습니다!", RoutingView.MAIN)
+        val now = LocalDateTime.now()
+        val currentRanking = userStatRepository.getAllRankingBy(RankingCriteria.TOTAL_CALORIES, PeriodType.MONTHLY)
+            .take(100)
+        val currentRankingBoard =
+            RankingBoard.of(
+                id = PeriodType.MONTHLY,
+                ranking = currentRanking,
+            )
+
+        val previousRankingBoard =
+            runCatching { rankingService.getRankingBoard(PeriodType.MONTHLY) }
+                .getOrElse {
+                    rankingService.updateRankingBoard(currentRankingBoard)
+                    return
+                }
+
+        // 매달 1일에는 갱신만 수행한다.
+        if (now.dayOfMonth == 1) {
+            rankingService.updateRankingBoard(currentRankingBoard)
+            return
         }
+
+        // 랭킹 차이가 있을 경우 푸시 알림
+        previousRankingBoard.ranking.forEach { (previousRank, previousUserStat) ->
+            val currentUserStat = currentRankingBoard.ranking.find { it.second.user.id == previousUserStat.user.id }
+            // 현재 랭킹에 없거나 순위가 떨어진경우
+            if (isRankingDown(currentUserStat, previousRank)) {
+                userRepository
+                    .findByIdOrNull(currentUserStat!!.second.user.id)!!
+                    .takeIf { it.setting.isAppPushOn && it.deviceToken != null }
+                    ?.let { sendPushToUser(it.deviceToken!!, "\uD83D\uDCC9  순위가 떨어졌어요!", RoutingView.MAIN) }
+            }
+        }
+        rankingService.updateRankingBoard(currentRankingBoard)
     }
 
     private fun sendPushToAllUsers(deviceTokens: List<String>, message: String, routingView: RoutingView) {
         if (deviceTokens.isEmpty()) return
-        
+
         val requests = deviceTokens
             .filter { it != "deviceToken" }
             .map { token ->
@@ -71,13 +97,13 @@ class NotificationService(
                     .putData("routingView", routingView.name)
                     .build()
             }
-        
+
         fcmClient.sendEach(requests)
     }
 
     private fun sendPushToUser(deviceToken: String, message: String, routingView: RoutingView) {
         if (deviceToken == "deviceToken") return
-        
+
         val request = Message
             .builder()
             .setToken(deviceToken)
@@ -87,4 +113,9 @@ class NotificationService(
 
         fcmClient.send(request)
     }
+
+    private fun isRankingDown(
+        currentUserStat: Pair<Int, UserStat>?,
+        previousRank: Int,
+    ) = (currentUserStat == null || currentUserStat.first > previousRank)
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/RankingService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/RankingService.kt
@@ -1,6 +1,5 @@
 package notbe.tmtm.ddanddanserver.application.service
 
-import notbe.tmtm.ddanddanserver.domain.exception.NotFoundUserStatException
 import notbe.tmtm.ddanddanserver.domain.model.ranking.*
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.*
 import org.bson.types.ObjectId
@@ -25,18 +24,9 @@ class RankingService(
     }
 
     @Transactional(readOnly = true)
-    fun getRankingWithRank(
-        userId: ObjectId,
-        criteria: RankingCriteria,
-        periodType: PeriodType,
-    ): Pair<List<Pair<UserStat, Int>>, Pair<UserStat, Int>> {
-        val userStats = userStatRepository.getAllRankingBy(criteria, periodType)
-        val userStatsWithRank = when (criteria) {
-            RankingCriteria.TOTAL_CALORIES -> getRankingList(userStats) { it.totalCalories }
-            RankingCriteria.TOTAL_SUCCEEDED_DAYS -> getRankingList(userStats) { it.totalSucceededDays }
-        }
-
-        return Pair(userStatsWithRank.take(RANKING_LIMIT), getMyStats(userStatsWithRank, userId))
+    fun getTopRanking(criteria: RankingCriteria, periodType: PeriodType): UserStat? {
+        val userStats: List<UserStat> = userStatRepository.getAllRankingBy(criteria, periodType)
+        return if (userStats.isEmpty()) null else userStats.first()
     }
 
     @Transactional(readOnly = true)
@@ -44,33 +34,8 @@ class RankingService(
         return rankingBoardRepository.findByIdOrDefault(periodType)
     }
 
-    @Transactional(readOnly = true)
-    fun getTopRanking(criteria: RankingCriteria, periodType: PeriodType): UserStat? {
-        val userStats: List<UserStat> = userStatRepository.getAllRankingBy(criteria, periodType)
-        return if (userStats.isEmpty()) null else userStats.first()
-    }
-
     @Transactional
     fun updateRankingBoard(rankingBoard: RankingBoard): RankingBoard {
         return rankingBoardRepository.save(rankingBoard)
-    }
-
-    private fun getRankingList(
-        userStats: List<UserStat>,
-        field: (UserStat) -> Int,
-    ): List<Pair<UserStat, Int>> =
-        userStats
-            .foldIndexed(emptyList<Pair<UserStat, Int>>() to 1) { index, (acc, lastRank), user ->
-                val rank = if (index > 0 && field(user) == field(acc.last().first)) lastRank else index + 1
-                (acc + (user to rank)) to rank
-            }.first
-
-    private fun getMyStats(
-        userStats: List<Pair<UserStat, Int>>,
-        userId: ObjectId,
-    ): Pair<UserStat, Int> {
-        val myStats = userStats.find { it.first.userId == userId }
-            ?: throw NotFoundUserStatException("갱신하지 않은 사용자입니다. userId=$userId")
-        return myStats
     }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/ranking/RankingResult.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/ranking/RankingResult.kt
@@ -16,10 +16,10 @@ data class RankingResult private constructor(
         fun create(
             userStats: List<UserStat>,
             criteria: RankingCriteria,
-            userId: ObjectId,
+            myUserId: ObjectId,
         ): RankingResult {
             val sortedUserRankings = calculateRankings(userStats, criteria)
-            val myRanking = findMyRanking(sortedUserRankings, userId)
+            val myRanking = findMyRanking(sortedUserRankings, myUserId)
 
             return RankingResult(sortedUserRankings, myRanking)
         }
@@ -50,7 +50,7 @@ data class RankingResult private constructor(
             rankings: List<UserRanking>,
             userId: ObjectId,
         ): UserRanking =
-            rankings.find { it.userStat.userId == userId }
+            rankings.find { it.userStat.user.id == userId }
                 ?: throw NotFoundUserStatException("갱신하지 않은 사용자입니다. userId=$userId")
     }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/ranking/UserStat.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/ranking/UserStat.kt
@@ -1,12 +1,11 @@
 package notbe.tmtm.ddanddanserver.domain.model.ranking
 
-import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
-import org.bson.types.ObjectId
+import notbe.tmtm.ddanddanserver.domain.model.pet.Pet
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 
 data class UserStat(
-    val userId: ObjectId,
-    val userName: String,
-    val mainPetType: PetType,
+    val user: User,
+    val mainPet: Pet,
     val totalCalories: Int,
     val totalSucceededDays: Int,
 )

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/UserStatEntity.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/UserStatEntity.kt
@@ -1,38 +1,31 @@
 package notbe.tmtm.ddanddanserver.infrastructure.database.entity
 
-import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
+import notbe.tmtm.ddanddanserver.domain.model.pet.Pet
 import notbe.tmtm.ddanddanserver.domain.model.ranking.UserStat
-import org.bson.types.ObjectId
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 
 data class UserStatEntity(
-    val userId: ObjectId,
-    val userName: String?,
-    val mainPetType: String?,
+    val user: User,
+    val mainPet: Pet,
     val totalCalories: Int,
     val totalSucceededDays: Int,
 ) {
     companion object {
         fun fromDomain(userStat: UserStat): UserStatEntity =
             UserStatEntity(
-                userId = userStat.userId,
-                userName = userStat.userName,
-                mainPetType = userStat.mainPetType.name,
+                user = userStat.user,
+                mainPet = userStat.mainPet,
                 totalCalories = userStat.totalCalories,
                 totalSucceededDays = userStat.totalSucceededDays,
             )
     }
 
-    fun toDomain(): UserStat {
-        val userStat =
-            UserStat(
-                userId = userId,
-                userName = userName ?: throw IllegalStateException("userName is null"),
-                mainPetType =
-                    mainPetType?.let { PetType.valueOf(it) }
-                        ?: throw IllegalStateException("mainPetType is null"),
-                totalCalories = totalCalories,
-                totalSucceededDays = totalSucceededDays,
-            )
-        return userStat
-    }
+    fun toDomain(): UserStat =
+        UserStat(
+            user = user,
+            mainPet = mainPet,
+            totalCalories = totalCalories,
+            totalSucceededDays = totalSucceededDays,
+        )
+
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserStatRepositoryImpl.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserStatRepositoryImpl.kt
@@ -6,7 +6,7 @@ import notbe.tmtm.ddanddanserver.domain.model.user.DailyInfo
 import notbe.tmtm.ddanddanserver.infrastructure.database.entity.UserStatEntity
 import org.springframework.data.domain.Sort
 import org.springframework.data.mongodb.core.MongoTemplate
-import org.springframework.data.mongodb.core.aggregation.Aggregation.*
+import org.springframework.data.mongodb.core.aggregation.Aggregation
 import org.springframework.data.mongodb.core.aggregation.ConditionalOperators.Cond
 import org.springframework.data.mongodb.core.query.Criteria
 import org.springframework.stereotype.Repository
@@ -20,30 +20,55 @@ class UserStatRepositoryImpl(
         criteria: RankingCriteria,
         periodType: PeriodType,
     ): List<UserStatEntity> {
-        val agg =
-            newAggregation(
-                match(
-                    Criteria
-                        .where(DailyInfo::date.name)
-                        .gte(periodType.currentStartDate())
-                        .lte(periodType.currentEndDate()),
-                ),
-                group(DailyInfo::userId.name)
-                    .first(DailyInfo::userId.name)
-                    .`as`(UserStatEntity::userId.toSnakeCase())
-                    .last(DailyInfo::userName.name)
-                    .`as`(UserStatEntity::userName.toSnakeCase())
-                    .last(DailyInfo::petType.name)
-                    .`as`(UserStatEntity::mainPetType.toSnakeCase())
-                    .sum(DailyInfo::calorie.name)
-                    .`as`(UserStatEntity::totalCalories.toSnakeCase())
-                    .sum(Cond.`when`(DailyInfo::purposeAchieved.toSnakeCase()).then(1).otherwise(0))
-                    .`as`(UserStatEntity::totalSucceededDays.toSnakeCase()),
-                sort(Sort.Direction.DESC, criteria.fieldName())
-                    .and(Sort.Direction.ASC, UserStatEntity::userId.toSnakeCase()),
-            )
-        return mongoTemplate.aggregate(agg, DailyInfo::class.java, UserStatEntity::class.java).mappedResults
+        val matchCriteria = getMatchCriteria(periodType)
+        val groupStage = getGroupStage()
+        val lookupUser = getLookupUser()
+        val lookupPet = getLookupPet()
+        val sort = getSort(criteria)
+
+        val agg = Aggregation.newAggregation(
+            matchCriteria,
+            groupStage,
+            lookupUser,
+            Aggregation.unwind("user", false),
+            lookupPet,
+            Aggregation.unwind("main_pet", false),
+            sort,
+        )
+        return mongoTemplate.aggregate(agg, DailyInfo::class.java, UserStatEntity::class.java)
+            .mappedResults
     }
+
+    private fun getMatchCriteria(periodType: PeriodType) = Aggregation.match(
+        Criteria
+            .where(DailyInfo::date.name)
+            .gte(periodType.currentStartDate())
+            .lte(periodType.currentEndDate()),
+    )
+
+    private fun getGroupStage() = Aggregation.group(DailyInfo::userId.name)
+        .sum(DailyInfo::calorie.name)
+        .`as`(UserStatEntity::totalCalories.toSnakeCase())
+        .sum(Cond.`when`(DailyInfo::purposeAchieved.toSnakeCase()).then(1).otherwise(0))
+        .`as`(UserStatEntity::totalSucceededDays.toSnakeCase())
+
+    private fun getLookupUser() = Aggregation.lookup()
+        .from("users")
+        .localField("_id")
+        .foreignField("_id")
+        .pipeline(Aggregation.limit(1))
+        .`as`("user")
+
+    private fun getLookupPet() = Aggregation.lookup()
+        .from("pets")
+        .localField("user.main_pet_id")
+        .foreignField("_id")
+        .pipeline(Aggregation.limit(1))
+        .`as`("main_pet")
+
+    private fun getSort(criteria: RankingCriteria) =
+        Aggregation.sort(Sort.Direction.DESC, criteria.fieldName())
+            .and(Sort.Direction.ASC, "user._id")
 
     private fun RankingCriteria.fieldName(): String = this.name.lowercase()
 
@@ -51,4 +76,5 @@ class UserStatRepositoryImpl(
         this.name
             .replace(Regex("([a-z])([A-Z])"), "$1_$2")
             .lowercase()
+
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/RankingResponse.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/RankingResponse.kt
@@ -2,11 +2,7 @@ package notbe.tmtm.ddanddanserver.presentation.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
-import notbe.tmtm.ddanddanserver.domain.model.ranking.PeriodType
-import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingCriteria
-import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingResult
-import notbe.tmtm.ddanddanserver.domain.model.ranking.UserRanking
-import notbe.tmtm.ddanddanserver.domain.model.ranking.UserStat
+import notbe.tmtm.ddanddanserver.domain.model.ranking.*
 
 @Schema(description = "랭킹 조회 응답 DTO")
 data class RankingResponse(
@@ -42,18 +38,18 @@ data class RankingResponse(
                 userStat: UserStat,
             ) = RankingUserStatResponse(
                 rank = rank,
-                userId = userStat.userId.toHexString(),
-                userName = userStat.userName,
-                mainPetType = userStat.mainPetType,
+                userId = userStat.user.id.toHexString(),
+                userName = userStat.user.name!!,
+                mainPetType = userStat.mainPet.type,
+                petLevel = userStat.mainPet.getLevel().level,
                 totalCalories = userStat.totalCalories,
                 totalSucceededDays = userStat.totalSucceededDays,
             )
 
-            fun fromDomain(userRanking: UserRanking) =
-                fromDomain(
-                    rank = userRanking.rank,
-                    userStat = userRanking.userStat,
-                )
+            fun fromDomain(userRanking: UserRanking) = fromDomain(
+                rank = userRanking.rank,
+                userStat = userRanking.userStat,
+            )
         }
     }
 

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/RankingServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/RankingServiceTest.kt
@@ -36,7 +36,7 @@ class RankingServiceTest {
     fun setUp() {
         userStatRepository = mockk()
         rankingBoardRepository = mockk()
-        rankingService = RankingService(userStatRepository)
+        rankingService = RankingService(userStatRepository, rankingBoardRepository)
     }
 
     @Test

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/RankingServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/RankingServiceTest.kt
@@ -3,10 +3,12 @@ package notbe.tmtm.ddanddanserver.application.service
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import notbe.tmtm.ddanddanserver.domain.model.pet.Pet
 import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
 import notbe.tmtm.ddanddanserver.domain.model.ranking.PeriodType
 import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingCriteria
 import notbe.tmtm.ddanddanserver.domain.model.ranking.UserStat
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.infrastructure.database.entity.UserStatEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.RankingBoardRepository
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserStatRepository
@@ -21,25 +23,30 @@ class RankingServiceTest {
     private lateinit var rankingBoardRepository: RankingBoardRepository
     private lateinit var rankingService: RankingService
 
+    private val user = createUser("user")
+    private val pet = createPet(user.id)
+    private val user1 = createUser("user1")
+    private val pet1 = createPet(user1.id)
+    private val user2 = createUser("user2")
+    private val pet2 = createPet(user2.id)
+    private val user3 = createUser("user3")
+    private val pet3 = createPet(user3.id)
+
     @BeforeEach
     fun setUp() {
         userStatRepository = mockk()
         rankingBoardRepository = mockk()
-        rankingService = RankingService(userStatRepository, rankingBoardRepository)
+        rankingService = RankingService(userStatRepository)
     }
 
     @Test
     fun `총 칼로리 기준으로 랭킹을 조회해야 한다`() {
         // given
-        val userId1 = ObjectId()
-        val userId2 = ObjectId()
-        val userId3 = ObjectId()
-
         val userStatEntities =
             listOf(
-                createUserStatEntity(userId1, "사용자1", 1000, 10),
-                createUserStatEntity(userId2, "사용자2", 800, 15),
-                createUserStatEntity(userId3, "사용자3", 600, 20),
+                createUserStatEntity(user1, pet1, 1000, 10),
+                createUserStatEntity(user2, pet2, 800, 15),
+                createUserStatEntity(user3, pet3, 600, 20),
             )
 
         every {
@@ -47,7 +54,7 @@ class RankingServiceTest {
         } returns userStatEntities
 
         // when
-        val result = rankingService.getRanking(userId2, RankingCriteria.TOTAL_CALORIES, PeriodType.WEEKLY)
+        val result = rankingService.getRanking(user2.id, RankingCriteria.TOTAL_CALORIES, PeriodType.WEEKLY)
 
         // then
         verify { userStatRepository.findAllRankingBy(RankingCriteria.TOTAL_CALORIES, PeriodType.WEEKLY) }
@@ -57,34 +64,30 @@ class RankingServiceTest {
 
         // 랭킹 순서 확인 (칼로리 높은 순)
         assertEquals(1, result.rankings[0].rank)
-        assertEquals(userId1, result.rankings[0].userStat.userId)
+        assertEquals(user1, result.rankings[0].userStat.user)
         assertEquals(1000, result.rankings[0].userStat.totalCalories)
 
         assertEquals(2, result.rankings[1].rank)
-        assertEquals(userId2, result.rankings[1].userStat.userId)
+        assertEquals(user2, result.rankings[1].userStat.user)
         assertEquals(800, result.rankings[1].userStat.totalCalories)
 
         assertEquals(3, result.rankings[2].rank)
-        assertEquals(userId3, result.rankings[2].userStat.userId)
+        assertEquals(user3, result.rankings[2].userStat.user)
         assertEquals(600, result.rankings[2].userStat.totalCalories)
 
         // 내 랭킹 확인
         assertEquals(2, result.myRanking.rank)
-        assertEquals(userId2, result.myRanking.userStat.userId)
+        assertEquals(user2, result.myRanking.userStat.user)
     }
 
     @Test
     fun `총 성공일 기준으로 랭킹을 조회해야 한다`() {
         // given
-        val userId1 = ObjectId()
-        val userId2 = ObjectId()
-        val userId3 = ObjectId()
-
         val userStatEntities =
             listOf(
-                createUserStatEntity(userId1, "사용자1", 500, 25), // 가장 많은 성공일
-                createUserStatEntity(userId2, "사용자2", 1000, 20),
-                createUserStatEntity(userId3, "사용자3", 800, 15),
+                createUserStatEntity(user1, pet1, 500, 25), // 가장 많은 성공일
+                createUserStatEntity(user2, pet2, 1000, 20),
+                createUserStatEntity(user3, pet3, 800, 15),
             )
 
         every {
@@ -92,7 +95,7 @@ class RankingServiceTest {
         } returns userStatEntities
 
         // when
-        val result = rankingService.getRanking(userId3, RankingCriteria.TOTAL_SUCCEEDED_DAYS, PeriodType.MONTHLY)
+        val result = rankingService.getRanking(user3.id, RankingCriteria.TOTAL_SUCCEEDED_DAYS, PeriodType.MONTHLY)
 
         // then
         verify { userStatRepository.findAllRankingBy(RankingCriteria.TOTAL_SUCCEEDED_DAYS, PeriodType.MONTHLY) }
@@ -102,29 +105,28 @@ class RankingServiceTest {
 
         // 랭킹 순서 확인 (성공일 높은 순)
         assertEquals(1, result.rankings[0].rank)
-        assertEquals(userId1, result.rankings[0].userStat.userId)
+        assertEquals(user1, result.rankings[0].userStat.user)
         assertEquals(25, result.rankings[0].userStat.totalSucceededDays)
 
         assertEquals(2, result.rankings[1].rank)
-        assertEquals(userId2, result.rankings[1].userStat.userId)
+        assertEquals(user2, result.rankings[1].userStat.user)
         assertEquals(20, result.rankings[1].userStat.totalSucceededDays)
 
         assertEquals(3, result.rankings[2].rank)
-        assertEquals(userId3, result.rankings[2].userStat.userId)
+        assertEquals(user3, result.rankings[2].userStat.user)
         assertEquals(15, result.rankings[2].userStat.totalSucceededDays)
 
         // 내 랭킹 확인
         assertEquals(3, result.myRanking.rank)
-        assertEquals(userId3, result.myRanking.userStat.userId)
+        assertEquals(user3, result.myRanking.userStat.user)
     }
 
     @Test
     fun `일간 기간 타입을 처리해야 한다`() {
         // given
-        val userId = ObjectId()
         val userStatEntities =
             listOf(
-                createUserStatEntity(userId, "사용자1", 100, 1),
+                createUserStatEntity(user, pet1, 100, 1),
             )
 
         every {
@@ -132,7 +134,7 @@ class RankingServiceTest {
         } returns userStatEntities
 
         // when
-        val result = rankingService.getRanking(userId, RankingCriteria.TOTAL_CALORIES, PeriodType.DAILY)
+        val result = rankingService.getRanking(user.id, RankingCriteria.TOTAL_CALORIES, PeriodType.DAILY)
 
         // then
         verify { userStatRepository.findAllRankingBy(RankingCriteria.TOTAL_CALORIES, PeriodType.DAILY) }
@@ -144,10 +146,9 @@ class RankingServiceTest {
     @Test
     fun `연간 기간 타입을 처리해야 한다`() {
         // given
-        val userId = ObjectId()
         val userStatEntities =
             listOf(
-                createUserStatEntity(userId, "사용자1", 10000, 365),
+                createUserStatEntity(user, pet1, 10000, 365),
             )
 
         every {
@@ -155,7 +156,7 @@ class RankingServiceTest {
         } returns userStatEntities
 
         // when
-        val result = rankingService.getRanking(userId, RankingCriteria.TOTAL_SUCCEEDED_DAYS, PeriodType.YEARLY)
+        val result = rankingService.getRanking(user.id, RankingCriteria.TOTAL_SUCCEEDED_DAYS, PeriodType.YEARLY)
 
         // then
         verify { userStatRepository.findAllRankingBy(RankingCriteria.TOTAL_SUCCEEDED_DAYS, PeriodType.YEARLY) }
@@ -167,11 +168,13 @@ class RankingServiceTest {
     @Test
     fun `대용량 데이터셋을 올바르게 처리해야 한다`() {
         // given
-        val targetUserId = ObjectId()
+        val targetUser = createUser("targetUser")
+        val targetPet = createPet(targetUser.id)
+
         val userStatEntities =
             (1..200).map { index ->
-                val userId = if (index == 150) targetUserId else ObjectId()
-                createUserStatEntity(userId, "사용자$index", 2000 - index, index)
+                val user = if (index == 150) targetUser else createUser("useruser")
+                createUserStatEntity(user, pet, 2000 - index, index)
             }
 
         every {
@@ -179,7 +182,7 @@ class RankingServiceTest {
         } returns userStatEntities
 
         // when
-        val result = rankingService.getRanking(targetUserId, RankingCriteria.TOTAL_CALORIES, PeriodType.WEEKLY)
+        val result = rankingService.getRanking(targetUser.id, RankingCriteria.TOTAL_CALORIES, PeriodType.WEEKLY)
 
         // then
         verify { userStatRepository.findAllRankingBy(RankingCriteria.TOTAL_CALORIES, PeriodType.WEEKLY) }
@@ -187,9 +190,9 @@ class RankingServiceTest {
         assertNotNull(result)
         assertEquals(200, result.rankings.size)
 
-        // 내 랭킹 확인 (150번째 사용자는 150위여야 함)
+        // 내 랭킹 확인 (pet째사용자는 150위여야 함)
         assertEquals(150, result.myRanking.rank)
-        assertEquals(targetUserId, result.myRanking.userStat.userId)
+        assertEquals(targetUser.id, result.myRanking.userStat.user.id)
 
         // 상위 랭킹 제한 기능 확인
         val top10 = result.getTopRankings(10)
@@ -201,15 +204,11 @@ class RankingServiceTest {
     @Test
     fun `서비스를 통해 동점 랭킹을 처리해야 한다`() {
         // given
-        val userId1 = ObjectId()
-        val userId2 = ObjectId()
-        val userId3 = ObjectId()
-
         val userStatEntities =
             listOf(
-                createUserStatEntity(userId1, "사용자1", 1000, 10),
-                createUserStatEntity(userId2, "사용자2", 800, 15), // 사용자3과 동점
-                createUserStatEntity(userId3, "사용자3", 800, 20), // 사용자2와 동점
+                createUserStatEntity(user1, pet1, 1000, 10),
+                createUserStatEntity(user2, pet2, 800, 15), // 사용자3과 동점
+                createUserStatEntity(user3, pet3, 800, 20), // 사용자2와 동점
             )
 
         every {
@@ -217,7 +216,7 @@ class RankingServiceTest {
         } returns userStatEntities
 
         // when
-        val result = rankingService.getRanking(userId2, RankingCriteria.TOTAL_CALORIES, PeriodType.WEEKLY)
+        val result = rankingService.getRanking(user2.id, RankingCriteria.TOTAL_CALORIES, PeriodType.WEEKLY)
 
         // then
         assertEquals(3, result.rankings.size)
@@ -226,21 +225,24 @@ class RankingServiceTest {
         assertEquals(2, result.rankings[2].rank) // 사용자3도 2위 (동점)
 
         assertEquals(2, result.myRanking.rank)
-        assertEquals(userId2, result.myRanking.userStat.userId)
+        assertEquals(user2.id, result.myRanking.userStat.user.id)
     }
 
+    private fun createUser(name: String): User = User.register("deviceToken-${name.lowercase()}", name)
+
+    private fun createPet(ownerId: ObjectId): Pet = Pet.register(PetType.getRandom(), ownerId)
+
     private fun createUserStatEntity(
-        userId: ObjectId,
-        userName: String,
+        user: User,
+        mainPet: Pet,
         totalCalories: Int,
         totalSucceededDays: Int,
     ): UserStatEntity {
         val entity = mockk<UserStatEntity>()
         every { entity.toDomain() } returns
                 UserStat(
-                    userId = userId,
-                    userName = userName,
-                    mainPetType = PetType.DOG,
+                    user = user,
+                    mainPet = mainPet,
                     totalCalories = totalCalories,
                     totalSucceededDays = totalSucceededDays,
                 )

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/model/ranking/RankingResultTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/model/ranking/RankingResultTest.kt
@@ -1,7 +1,9 @@
 package notbe.tmtm.ddanddanserver.domain.model.ranking
 
 import notbe.tmtm.ddanddanserver.domain.exception.NotFoundUserStatException
+import notbe.tmtm.ddanddanserver.domain.model.pet.Pet
 import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import org.bson.types.ObjectId
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -10,119 +12,114 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class RankingResultTest {
+    private val user1 = createUser("user1")
+    private val pet1 = createPet(user1.id)
+    private val user2 = createUser("user2")
+    private val pet2 = createPet(user2.id)
+    private val user3 = createUser("user3")
+    private val pet3 = createPet(user3.id)
+    private val user4 = createUser("user4")
+    private val pet4 = createPet(user4.id)
+
     @Test
     fun `총 칼로리 기준으로 올바른 순서의 랭킹을 생성해야 한다`() {
         // given
-        val userId1 = ObjectId()
-        val userId2 = ObjectId()
-        val userId3 = ObjectId()
-
         val userStats =
             listOf(
-                createUserStat(userId1, "사용자1", 1000, 10), // 1위
-                createUserStat(userId2, "사용자2", 800, 15), // 2위
-                createUserStat(userId3, "사용자3", 600, 20), // 3위
+                createUserStat(user1, pet1, 1000, 10), // 1위
+                createUserStat(user2, pet2, 800, 15), // 2위
+                createUserStat(user3, pet3, 600, 20), // 3위
             )
 
         // when
-        val result = RankingResult.create(userStats, RankingCriteria.TOTAL_CALORIES, userId2)
+        val result = RankingResult.create(userStats, RankingCriteria.TOTAL_CALORIES, user2.id)
 
         // then
         assertEquals(3, result.rankings.size)
         assertEquals(1, result.rankings[0].rank)
-        assertEquals(userId1, result.rankings[0].userStat.userId)
+        assertEquals(user1, result.rankings[0].userStat.user)
         assertEquals(2, result.rankings[1].rank)
-        assertEquals(userId2, result.rankings[1].userStat.userId)
+        assertEquals(user2, result.rankings[1].userStat.user)
         assertEquals(3, result.rankings[2].rank)
-        assertEquals(userId3, result.rankings[2].userStat.userId)
+        assertEquals(user3, result.rankings[2].userStat.user)
 
         // 내 랭킹은 사용자2로 2위여야 함
         assertEquals(2, result.myRanking.rank)
-        assertEquals(userId2, result.myRanking.userStat.userId)
+        assertEquals(user2, result.myRanking.userStat.user)
     }
 
     @Test
     fun `총 성공일 기준으로 올바른 순서의 랭킹을 생성해야 한다`() {
         // given
-        val userId1 = ObjectId()
-        val userId2 = ObjectId()
-        val userId3 = ObjectId()
-
         val userStats =
             listOf(
-                createUserStat(userId1, "사용자1", 500, 25), // 1위 (가장 많은 성공일)
-                createUserStat(userId2, "사용자2", 1000, 20), // 2위
-                createUserStat(userId3, "사용자3", 800, 15), // 3위
+                createUserStat(user1, pet1, 500, 25), // 1위 (가장 많은 성공일)
+                createUserStat(user2, pet2, 1000, 20), // 2위
+                createUserStat(user3, pet3, 800, 15), // 3위
             )
 
         // when
-        val result = RankingResult.create(userStats, RankingCriteria.TOTAL_SUCCEEDED_DAYS, userId1)
+        val result = RankingResult.create(userStats, RankingCriteria.TOTAL_SUCCEEDED_DAYS, user1.id)
 
         // then
         assertEquals(3, result.rankings.size)
         assertEquals(1, result.rankings[0].rank)
-        assertEquals(userId1, result.rankings[0].userStat.userId)
+        assertEquals(user1, result.rankings[0].userStat.user)
         assertEquals(2, result.rankings[1].rank)
-        assertEquals(userId2, result.rankings[1].userStat.userId)
+        assertEquals(user2, result.rankings[1].userStat.user)
         assertEquals(3, result.rankings[2].rank)
-        assertEquals(userId3, result.rankings[2].userStat.userId)
+        assertEquals(user3, result.rankings[2].userStat.user)
 
         // 내 랭킹은 사용자1로 1위여야 함
         assertEquals(1, result.myRanking.rank)
-        assertEquals(userId1, result.myRanking.userStat.userId)
+        assertEquals(user1, result.myRanking.userStat.user)
     }
 
     @Test
     fun `동점자가 있는 랭킹을 올바르게 처리해야 한다`() {
         // given
-        val userId1 = ObjectId()
-        val userId2 = ObjectId()
-        val userId3 = ObjectId()
-        val userId4 = ObjectId()
-
         val userStats =
             listOf(
-                createUserStat(userId1, "사용자1", 1000, 10), // 1위
-                createUserStat(userId2, "사용자2", 800, 15), // 2위 (동점)
-                createUserStat(userId3, "사용자3", 800, 20), // 2위 (동점)
-                createUserStat(userId4, "사용자4", 600, 25), // 4위
+                createUserStat(user1, pet1, 1000, 10), // 1위
+                createUserStat(user2, pet2, 800, 15), // 2위 (동점)
+                createUserStat(user3, pet3, 800, 20), // 2위 (동점)
+                createUserStat(user4, pet4, 600, 25), // 4위
             )
 
         // when
-        val result = RankingResult.create(userStats, RankingCriteria.TOTAL_CALORIES, userId3)
+        val result = RankingResult.create(userStats, RankingCriteria.TOTAL_CALORIES, user3.id)
 
         // then
         assertEquals(4, result.rankings.size)
         assertEquals(1, result.rankings[0].rank)
-        assertEquals(userId1, result.rankings[0].userStat.userId)
+        assertEquals(user1, result.rankings[0].userStat.user)
         assertEquals(2, result.rankings[1].rank)
-        assertEquals(userId2, result.rankings[1].userStat.userId)
+        assertEquals(user2, result.rankings[1].userStat.user)
         assertEquals(2, result.rankings[2].rank) // 동점으로 같은 순위
-        assertEquals(userId3, result.rankings[2].userStat.userId)
+        assertEquals(user3, result.rankings[2].userStat.user)
         assertEquals(4, result.rankings[3].rank) // 3순위는 건너뜨
-        assertEquals(userId4, result.rankings[3].userStat.userId)
+        assertEquals(user4, result.rankings[3].userStat.user)
 
         // 내 랭킹은 사용자3로 2위여야 함 (동점)
         assertEquals(2, result.myRanking.rank)
-        assertEquals(userId3, result.myRanking.userStat.userId)
+        assertEquals(user3, result.myRanking.userStat.user)
     }
 
     @Test
     fun `랭킹에서 사용자를 찾을 수 없을 때 예외를 발생시켜야 한다`() {
         // given
-        val userId1 = ObjectId()
-        val userId2 = ObjectId()
-        val nonExistentUserId = ObjectId()
+        val nonExistentUser = createUser("nonExistentUser")
+        val nonExistentPet = createPet(nonExistentUser.id)
 
         val userStats =
             listOf(
-                createUserStat(userId1, "사용자1", 1000, 10),
-                createUserStat(userId2, "사용자2", 800, 15),
+                createUserStat(user1, pet1, 1000, 10),
+                createUserStat(user2, pet2, 800, 15),
             )
 
         // when & then
         assertThrows<NotFoundUserStatException> {
-            RankingResult.create(userStats, RankingCriteria.TOTAL_CALORIES, nonExistentUserId)
+            RankingResult.create(userStats, RankingCriteria.TOTAL_CALORIES, nonExistentUser.id)
         }
     }
 
@@ -131,9 +128,9 @@ class RankingResultTest {
         // given
         val userStats =
             (1..150).map { index ->
-                createUserStat(ObjectId(), "사용자$index", 1000 - index, index)
+                createUserStat(user1, pet1, 1000 - index, index)
             }
-        val firstUserId = userStats[0].userId
+        val firstUserId = userStats[0].user.id
 
         // when
         val result = RankingResult.create(userStats, RankingCriteria.TOTAL_CALORIES, firstUserId)
@@ -152,17 +149,14 @@ class RankingResultTest {
     @Test
     fun `랭킹 순서의 불변성을 보장해야 한다`() {
         // given
-        val userId1 = ObjectId()
-        val userId2 = ObjectId()
-
         val userStats =
             listOf(
-                createUserStat(userId1, "사용자1", 1000, 10),
-                createUserStat(userId2, "사용자2", 800, 15),
+                createUserStat(user1, pet1, 1000, 10),
+                createUserStat(user2, pet2, 800, 15),
             )
 
         // when
-        val result = RankingResult.create(userStats, RankingCriteria.TOTAL_CALORIES, userId1)
+        val result = RankingResult.create(userStats, RankingCriteria.TOTAL_CALORIES, user1.id)
         val rankings1 = result.rankings
         val rankings2 = result.rankings
 
@@ -189,33 +183,37 @@ class RankingResultTest {
     @Test
     fun `단일 사용자를 올바르게 처리해야 한다`() {
         // given
-        val userId = ObjectId()
         val userStats =
             listOf(
-                createUserStat(userId, "사용자1", 1000, 10),
+                createUserStat(user1, pet1, 1000, 10),
             )
 
         // when
-        val result = RankingResult.create(userStats, RankingCriteria.TOTAL_CALORIES, userId)
+        val result = RankingResult.create(userStats, RankingCriteria.TOTAL_CALORIES, user1.id)
 
         // then
         assertEquals(1, result.rankings.size)
         assertEquals(1, result.rankings[0].rank)
-        assertEquals(userId, result.rankings[0].userStat.userId)
+        assertEquals(user1.id, result.rankings[0].userStat.user.id)
         assertEquals(1, result.myRanking.rank)
-        assertEquals(userId, result.myRanking.userStat.userId)
+        assertEquals(user1.id, result.myRanking.userStat.user.id)
     }
 
+    private fun createUser(name: String): User = User.register("deviceToken-${name.lowercase()}", name)
+
+    private fun createPet(ownerId: ObjectId): Pet = Pet.register(PetType.getRandom(), ownerId)
+
     private fun createUserStat(
-        userId: ObjectId,
-        userName: String,
+        user: User,
+        mainPet: Pet,
         totalCalories: Int,
         totalSucceededDays: Int,
-    ) = UserStat(
-        userId = userId,
-        userName = userName,
-        mainPetType = PetType.DOG,
-        totalCalories = totalCalories,
-        totalSucceededDays = totalSucceededDays,
-    )
+    ): UserStat {
+        return UserStat(
+            user = user,
+            mainPet = mainPet,
+            totalCalories = totalCalories,
+            totalSucceededDays = totalSucceededDays,
+        )
+    }
 }

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/model/ranking/UserRankingTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/model/ranking/UserRankingTest.kt
@@ -1,17 +1,21 @@
 package notbe.tmtm.ddanddanserver.domain.model.ranking
 
+import notbe.tmtm.ddanddanserver.domain.model.pet.Pet
 import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
+import notbe.tmtm.ddanddanserver.domain.model.user.User
 import org.bson.types.ObjectId
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 class UserRankingTest {
+    private val user = createUser("user")
+    private val pet = createPet(user.id)
+
     @Test
     fun `UserRanking을 올바른 속성으로 생성해야 한다`() {
         // given
-        val userId = ObjectId()
-        val userStat = createUserStat(userId, "테스트사용자", 1000, 10)
+        val userStat = createUserStat(user, pet, 1000, 10)
         val rank = 5
 
         // when
@@ -20,8 +24,8 @@ class UserRankingTest {
         // then
         assertEquals(userStat, userRanking.userStat)
         assertEquals(rank, userRanking.rank)
-        assertEquals(userId, userRanking.userStat.userId)
-        assertEquals("테스트사용자", userRanking.userStat.userName)
+        assertEquals(user, userRanking.userStat.user)
+        assertEquals("user", userRanking.userStat.user.name)
         assertEquals(1000, userRanking.userStat.totalCalories)
         assertEquals(10, userRanking.userStat.totalSucceededDays)
     }
@@ -29,8 +33,7 @@ class UserRankingTest {
     @Test
     fun `데이터 클래스 동등성을 지원해야 한다`() {
         // given
-        val userId = ObjectId()
-        val userStat = createUserStat(userId, "테스트사용자", 1000, 10)
+        val userStat = createUserStat(user, pet, 1000, 10)
         val rank = 3
 
         val userRanking1 = UserRanking(userStat, rank)
@@ -46,8 +49,7 @@ class UserRankingTest {
     @Test
     fun `데이터 클래스 복사를 지원해야 한다`() {
         // given
-        val userId = ObjectId()
-        val userStat = createUserStat(userId, "테스트사용자", 1000, 10)
+        val userStat = createUserStat(user, pet, 1000, 10)
         val originalRanking = UserRanking(userStat, 3)
 
         // when
@@ -62,8 +64,7 @@ class UserRankingTest {
     @Test
     fun `데이터 클래스 toString을 지원해야 한다`() {
         // given
-        val userId = ObjectId()
-        val userStat = createUserStat(userId, "테스트사용자", 1000, 10)
+        val userStat = createUserStat(user, pet, 1000, 10)
         val userRanking = UserRanking(userStat, 1)
 
         // when
@@ -78,8 +79,7 @@ class UserRankingTest {
     @Test
     fun `다양한 순위 값을 올바르게 처리해야 한다`() {
         // given
-        val userId = ObjectId()
-        val userStat = createUserStat(userId, "테스트사용자", 1000, 10)
+        val userStat = createUserStat(user, pet, 1000, 10)
 
         // when
         val firstPlace = UserRanking(userStat, 1)
@@ -98,38 +98,45 @@ class UserRankingTest {
     @Test
     fun `다양한 펫 타입과 함께 작동해야 한다`() {
         // given
-        val userId = ObjectId()
+        val dogUser = createUser("강아지주인")
+        val dogPet = Pet.register(PetType.DOG, dogUser.id)
+        val catUser = createUser("고양이주인")
+        val catPet = Pet.register(PetType.CAT, catUser.id)
 
         // when
         val dogRanking =
             UserRanking(
-                createUserStat(userId, "강아지주인", 1000, 10, PetType.DOG),
+                createUserStat(dogUser, dogPet, 1000, 10),
                 1,
             )
         val catRanking =
             UserRanking(
-                createUserStat(userId, "고양이주인", 800, 8, PetType.CAT),
+                createUserStat(catUser, catPet, 800, 8),
                 2,
             )
 
         // then
-        assertEquals(PetType.DOG, dogRanking.userStat.mainPetType)
-        assertEquals(PetType.CAT, catRanking.userStat.mainPetType)
+        assertEquals(dogPet.type, dogRanking.userStat.mainPet.type)
+        assertEquals(catPet.type, catRanking.userStat.mainPet.type)
         assertEquals(1, dogRanking.rank)
         assertEquals(2, catRanking.rank)
     }
 
+    private fun createUser(name: String): User = User.register("deviceToken-${name.lowercase()}", name)
+
+    private fun createPet(ownerId: ObjectId): Pet = Pet.register(PetType.getRandom(), ownerId)
+
     private fun createUserStat(
-        userId: ObjectId,
-        userName: String,
+        user: User,
+        mainPet: Pet,
         totalCalories: Int,
         totalSucceededDays: Int,
-        petType: PetType = PetType.DOG,
-    ) = UserStat(
-        userId = userId,
-        userName = userName,
-        mainPetType = petType,
-        totalCalories = totalCalories,
-        totalSucceededDays = totalSucceededDays,
-    )
+    ): UserStat {
+        return UserStat(
+            user = user,
+            mainPet = mainPet,
+            totalCalories = totalCalories,
+            totalSucceededDays = totalSucceededDays,
+        )
+    }
 }

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserStatRepositoryImplTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserStatRepositoryImplTest.kt
@@ -1,0 +1,30 @@
+package notbe.tmtm.ddanddanserver.infrastructure.database.repository
+
+import notbe.tmtm.ddanddanserver.domain.model.ranking.PeriodType
+import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingCriteria
+import org.junit.jupiter.api.Disabled
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import kotlin.test.Test
+
+@SpringBootTest
+@Disabled
+class UserStatRepositoryImplTest {
+
+    @Autowired
+    lateinit var userRankingRepository: UserStatRepositoryImpl
+
+    @Test
+    fun getUserRanking() {
+        val result = userRankingRepository.findAllRankingBy(
+            RankingCriteria.TOTAL_SUCCEEDED_DAYS,
+            PeriodType.YEARLY
+        )
+
+        println("Total Rankings: ${result.size}")
+
+        result.forEachIndexed { index, userRankingEntity ->
+            println(userRankingEntity)
+        }
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
- 랭킹 API에 고정으로 내렸던 레벨 반영
- 레벨을 내리기 위해 칼로리 + 유저 + 메인펫 정보를 조인하는 aggregation 쿼리로 변경
- 

## ➕ 기타
- 

close #210 
