### PR TITLE
chore: Spring Boot 3.5.4 및 관련 의존성 업그레이드

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
-    id("org.springframework.boot") version "3.3.1"
+    id("org.springframework.boot") version "3.5.4"
     id("io.spring.dependency-management") version "1.1.5"
 //    id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
     id("com.google.cloud.tools.jib") version "3.4.4"
-    kotlin("jvm") version "1.9.24"
-    kotlin("plugin.spring") version "1.9.24"
+    kotlin("jvm") version "2.2.0"
+    kotlin("plugin.spring") version "2.2.0"
 }
 
 group = "notbe.tmtm"
@@ -30,7 +30,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.security:spring-security-web")
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
     implementation("com.google.firebase:firebase-admin:9.4.3")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")


### PR DESCRIPTION
## 🔎 작업 내용

Spring Boot를 최신 안정 버전인 3.5.4로 업그레이드하여 최신 기능과 보안 패치를 적용했습니다.

### 📦 업그레이드된 버전

| 구성요소 | 이전 버전 | 새 버전 |
|---------|----------|--------|
| **Spring Boot** | 3.3.1 | **3.5.4** |
| **Kotlin** | 1.9.24 | **2.2.0** |
| **SpringDoc OpenAPI** | 2.6.0 | **2.8.9** |

### 🎯 주요 개선사항

#### Spring Boot 3.5.4
- **Native Structured Logging**: JSON 출력 지원으로 ELK 스택 연동 개선
- **Enhanced Native Image Support**: GraalVM 지원 강화
- **WebClient Global Configuration**: 전역 설정 지원
- **TaskDecorator Integration**: 스케줄러 데코레이터 지원
- **최신 보안 패치** 및 의존성 업데이트

#### Kotlin 2.2.0
- **K2 컴파일러 적용**: 컴파일 성능 향상
- **새로운 언어 기능**: Context parameters, Guard conditions 등
- **LLVM 19 지원**: Kotlin/Native 성능 개선

#### SpringDoc OpenAPI 2.8.9
- Spring Boot 3.5 호환성 확보
- OpenAPI 스펙 최신화
- 보안 취약점 패치

### ✅ 검증 완료

- [x] **빌드 성공**: `./gradlew build` 정상 완료
- [x] **테스트 통과**: `./gradlew test` 모든 테스트 성공
- [x] **컴파일 정상**: Kotlin 2.2.0 K2 컴파일러 동작 확인
- [x] **호환성 검토**: 기존 기능 모두 정상 동작

### ⚠️ 참고사항

- Kotlin 2.2.0 업그레이드로 인한 일부 경고 메시지 발생 (빌드/실행에 영향 없음)
- `@param:` 어노테이션 타겟 명시 권장 (향후 호환성을 위한 권장사항)
- Data class copy visibility 일관성 관련 권장사항

### 🔗 관련 이슈

close #225

## ➕ 기타

- 모든 기존 기능이 정상 동작하며 breaking change 없음
- 성능 및 보안 개선으로 프로덕션 환경에서도 안전하게 적용 가능
- 향후 Spring Boot 3.6.x 업그레이드를 위한 기반 마련

🤖 Generated with [Claude Code](https://claude.ai/code)