### PR TITLE
feat: 펫 가챠 시스템 구현

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/PetService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/PetService.kt
@@ -66,15 +66,22 @@ class PetService(
         return petRepository.findAllByOwnerUserId(ownerUserId)
     }
 
+    @Transactional
+    fun gachaPet(userId: ObjectId): Pet {
+        val existingPetTypes = petRepository.findAllByOwnerUserId(userId)
+            .map { it.type }
+            .distinct()
+
+        val addedPet = addPet(PetType.getRandomWithout(existingPetTypes), userId)
+        userRepository.decreaseTickets(userId, 1)
+
+        return addedPet
+    }
+
     private fun addPet(
         petType: PetType,
         ownerUserId: ObjectId
-    ) = petRepository.save(
-        Pet.register(
-            type = petType,
-            ownerUserId = ownerUserId,
-        ),
-    )
+    ) = petRepository.save(Pet.register(type = petType, ownerUserId = ownerUserId))
 
 
     data class FeedPetResult(

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/exception/ErrorCode.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/exception/ErrorCode.kt
@@ -54,6 +54,7 @@ enum class ErrorCode(
     USER_NOT_FOUND("UE001", "유저를 찾을 수 없습니다."),
     USER_FOOD_QUANTITY_LACK("UE002", "먹이가 부족합니다."),
     USER_TOY_QUANTITY_LACK("UE003", "장난감이 부족합니다."),
+    USER_TICKET_LACK("UE004", "티켓이 부족합니다."),
 
     /**
      * 펫 오류

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/exception/UserException.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/exception/UserException.kt
@@ -16,3 +16,7 @@ class UserFoodQuantityLackException(
 class UserToyQuantityLackException(
     data: Any? = null,
 ) : UserException(ErrorCode.USER_TOY_QUANTITY_LACK, data)
+
+class UserTicketLackException(
+    data: Any? = null,
+) : UserException(ErrorCode.USER_TICKET_LACK, data)

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/user/User.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/user/User.kt
@@ -16,6 +16,7 @@ class User(
     var foodQuantity: Int = 0,
     var toyQuantity: Int = 0,
     var purposeStrict: Int = 0,
+    var tickets: Int = 0,
     var setting: UserSetting = UserSetting(),
     var lastLoginAt: LocalDate = LocalDate.now(),
 ) {

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserRepository.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserRepository.kt
@@ -6,9 +6,7 @@ import org.bson.types.ObjectId
 import org.springframework.data.mongodb.repository.MongoRepository
 import org.springframework.data.repository.findByIdOrNull
 
-interface UserRepository : MongoRepository<User, ObjectId>
+interface UserRepository : MongoRepository<User, ObjectId>, UserRepositoryCustom
 
-fun UserRepository.findByIdOrThrow(userId: ObjectId): User {
-    return findByIdOrNull(userId)
-        ?: throw UserNotFoundException("User not found with id: $userId")
-}
+fun UserRepository.findByIdOrThrow(userId: ObjectId): User =
+    findByIdOrNull(userId) ?: throw UserNotFoundException("User not found with id: $userId")

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserRepositoryCustom.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserRepositoryCustom.kt
@@ -1,0 +1,9 @@
+package notbe.tmtm.ddanddanserver.infrastructure.database.repository
+
+import org.bson.types.ObjectId
+
+interface UserRepositoryCustom {
+    fun increaseTickets(userId: ObjectId, amount: Int)
+
+    fun decreaseTickets(userId: ObjectId, amount: Int)
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserRepositoryCustomImpl.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserRepositoryCustomImpl.kt
@@ -1,0 +1,48 @@
+package notbe.tmtm.ddanddanserver.infrastructure.database.repository
+
+import notbe.tmtm.ddanddanserver.domain.exception.UserNotFoundException
+import notbe.tmtm.ddanddanserver.domain.exception.UserTicketLackException
+import notbe.tmtm.ddanddanserver.domain.model.user.User
+import org.bson.types.ObjectId
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
+import org.springframework.data.mongodb.core.query.gt
+import org.springframework.data.mongodb.core.query.isEqualTo
+import org.springframework.data.mongodb.core.updateFirst
+import org.springframework.stereotype.Repository
+
+@Repository
+class UserRepositoryCustomImpl(
+    private val mongoTemplate: MongoTemplate,
+) : UserRepositoryCustom {
+    override fun increaseTickets(userId: ObjectId, amount: Int) {
+        val query = Query().addCriteria(
+            User::id isEqualTo userId,
+        )
+        val update = Update().inc("tickets", amount)
+
+        mongoTemplate.updateFirst<User>(query, update).let {
+            if (it.matchedCount == 0L) {
+                throw UserNotFoundException("유저를 찾을 수 없습니다. id: $userId")
+            }
+        }
+    }
+
+    override fun decreaseTickets(userId: ObjectId, amount: Int) {
+        val query = Query(
+            Criteria().andOperator(
+                User::id isEqualTo userId,
+                User::tickets gt 0,
+            )
+        )
+        val update = Update().inc("tickets", -amount)
+
+        mongoTemplate.updateFirst<User>(query, update).let {
+            if (it.matchedCount == 0L) {
+                throw UserTicketLackException("티켓이 부족합니다. id: $userId")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/PetController.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/PetController.kt
@@ -44,6 +44,13 @@ class PetController(
         return PetResponse.fromDomain(pet)
     }
 
+    @PostMapping("/me/gacha")
+    @Operation(summary = "티켓 랜덤 펫 뽑기", description = "티켓 하나를 소모하여, 랜덤으로 펫을 추가합니다.")
+    fun gachaRandomPet(authentication: Authentication): PetResponse {
+        val pet = petService.gachaPet(ObjectId(authentication.name))
+        return PetResponse.fromDomain(pet)
+    }
+
     @PostMapping("/{petId}/food")
     @Operation(summary = "펫 먹이 지급", description = "펫에게 먹이를 지급해 성장시킵니다.")
     fun feedPet(

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/UserResponse.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/UserResponse.kt
@@ -15,6 +15,8 @@ data class UserResponse(
     val foodQuantity: Int,
     @Schema(description = "User 장난감 수량", example = "2")
     val toyQuantity: Int,
+    @Schema(description = "User 티켓 수량", example = "0")
+    val tickets: Int = 0,
     @Schema(description = "User 설정 정보")
     val setting: UserSettingResponse,
 ) {
@@ -27,6 +29,7 @@ data class UserResponse(
                     purposeCalorie = purposeCalorie,
                     foodQuantity = foodQuantity,
                     toyQuantity = toyQuantity,
+                    tickets = tickets,
                     setting = UserSettingResponse.fromDomain(setting),
                 )
             }

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/PetServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/PetServiceTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import notbe.tmtm.ddanddanserver.domain.exception.PetNotFoundException
 import notbe.tmtm.ddanddanserver.domain.exception.UserNotFoundException
+import notbe.tmtm.ddanddanserver.domain.exception.UserTicketLackException
 import notbe.tmtm.ddanddanserver.domain.model.pet.Pet
 import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
 import notbe.tmtm.ddanddanserver.domain.model.user.User
@@ -222,6 +223,64 @@ class PetServiceTest : FunSpec({
 
         shouldThrow<PetNotFoundException> {
             petService.getMyPet(userId, petId)
+        }
+    }
+
+    context("gachaPet") {
+        test("가챠 펫: 티켓이 충분할 때 펫을 성공적으로 추가해야 한다") {
+            val userId = ObjectId()
+            val existingPet = mockk<Pet>()
+            val savedPet = mockk<Pet>()
+
+            every { existingPet.type } returns PetType.DOG
+            every { petRepository.findAllByOwnerUserId(userId) } returns listOf(existingPet)
+            every { petRepository.save(any()) } returns savedPet
+            every { userRepository.decreaseTickets(userId, 1) } returns Unit
+
+            val result = petService.gachaPet(userId)
+
+            verify { petRepository.findAllByOwnerUserId(userId) }
+            verify { petRepository.save(any()) }
+            verify { userRepository.decreaseTickets(userId, 1) }
+            result shouldBe savedPet
+        }
+
+        test("가챠 펫: 티켓이 부족할 때 UserTicketLackException을 발생시켜야 한다") {
+            val userId = ObjectId()
+            val existingPet = mockk<Pet>()
+            val savedPet = mockk<Pet>()
+
+            every { existingPet.type } returns PetType.DOG
+            every { petRepository.findAllByOwnerUserId(userId) } returns listOf(existingPet)
+            every { petRepository.save(any()) } returns savedPet
+            every { userRepository.decreaseTickets(userId, 1) } throws UserTicketLackException("티켓이 부족합니다")
+
+            shouldThrow<UserTicketLackException> {
+                petService.gachaPet(userId)
+            }
+
+            verify { petRepository.findAllByOwnerUserId(userId) }
+            verify { petRepository.save(any()) }
+            verify { userRepository.decreaseTickets(userId, 1) }
+        }
+
+        test("가챠 펫: 티켓 차감 시 사용자가 존재하지 않을 때 UserNotFoundException을 발생시켜야 한다") {
+            val userId = ObjectId()
+            val existingPet = mockk<Pet>()
+            val savedPet = mockk<Pet>()
+
+            every { existingPet.type } returns PetType.DOG
+            every { petRepository.findAllByOwnerUserId(userId) } returns listOf(existingPet)
+            every { petRepository.save(any()) } returns savedPet
+            every { userRepository.decreaseTickets(userId, 1) } throws UserNotFoundException("유저를 찾을 수 없습니다")
+
+            shouldThrow<UserNotFoundException> {
+                petService.gachaPet(userId)
+            }
+
+            verify { petRepository.findAllByOwnerUserId(userId) }
+            verify { petRepository.save(any()) }
+            verify { userRepository.decreaseTickets(userId, 1) }
         }
     }
 })

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/exception/UserTicketLackExceptionTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/domain/exception/UserTicketLackExceptionTest.kt
@@ -1,0 +1,31 @@
+package notbe.tmtm.ddanddanserver.domain.exception
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class UserTicketLackExceptionTest : FunSpec({
+
+    test("UserTicketLackException은 UserException을 상속해야 한다") {
+        val exception = UserTicketLackException()
+
+        exception.shouldBeInstanceOf<UserException>()
+        exception.shouldBeInstanceOf<CustomException>()
+    }
+
+    test("UserTicketLackException은 올바른 에러 코드를 가져야 한다") {
+        val exception = UserTicketLackException()
+
+        exception.errorCode shouldBe ErrorCode.USER_TICKET_LACK
+        exception.message shouldBe ErrorCode.USER_TICKET_LACK.message
+    }
+
+    test("UserTicketLackException은 데이터를 포함할 수 있어야 한다") {
+        val testData = mapOf("userId" to "123", "currentTickets" to 0, "requiredTickets" to 1)
+        val exception = UserTicketLackException(testData)
+
+        exception.errorCode shouldBe ErrorCode.USER_TICKET_LACK
+        exception.data shouldBe testData
+        exception.message shouldBe ErrorCode.USER_TICKET_LACK.message
+    }
+})

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserRepositoryCustomImplTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserRepositoryCustomImplTest.kt
@@ -1,0 +1,82 @@
+package notbe.tmtm.ddanddanserver.infrastructure.database.repository
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import notbe.tmtm.ddanddanserver.domain.exception.UserNotFoundException
+import notbe.tmtm.ddanddanserver.domain.exception.UserTicketLackException
+import notbe.tmtm.ddanddanserver.domain.model.user.User
+import org.bson.types.ObjectId
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
+import com.mongodb.client.result.UpdateResult
+
+class UserRepositoryCustomImplTest : FunSpec({
+    lateinit var mongoTemplate: MongoTemplate
+    lateinit var userRepositoryCustomImpl: UserRepositoryCustomImpl
+
+    beforeEach {
+        mongoTemplate = mockk()
+        userRepositoryCustomImpl = UserRepositoryCustomImpl(mongoTemplate)
+    }
+
+    context("increaseTickets") {
+        test("사용자가 존재할 때 티켓을 증가시켜야 한다") {
+            val userId = ObjectId()
+            val amount = 5
+            val updateResult = mockk<UpdateResult>()
+
+            every { updateResult.matchedCount } returns 1L
+            every { mongoTemplate.updateFirst(any<Query>(), any<Update>(), User::class.java) } returns updateResult
+
+            userRepositoryCustomImpl.increaseTickets(userId, amount)
+
+            verify { mongoTemplate.updateFirst(any<Query>(), any<Update>(), User::class.java) }
+        }
+
+        test("사용자가 존재하지 않을 때 UserNotFoundException을 발생시켜야 한다") {
+            val userId = ObjectId()
+            val amount = 5
+            val updateResult = mockk<UpdateResult>()
+
+            every { updateResult.matchedCount } returns 0L
+            every { mongoTemplate.updateFirst(any<Query>(), any<Update>(), User::class.java) } returns updateResult
+
+            shouldThrow<UserNotFoundException> {
+                userRepositoryCustomImpl.increaseTickets(userId, amount)
+            }
+        }
+    }
+
+    context("decreaseTickets") {
+        test("사용자가 존재하고 티켓이 충분할 때 티켓을 감소시켜야 한다") {
+            val userId = ObjectId()
+            val amount = 3
+            val updateResult = mockk<UpdateResult>()
+
+            every { updateResult.matchedCount } returns 1L
+            every { mongoTemplate.updateFirst(any<Query>(), any<Update>(), User::class.java) } returns updateResult
+
+            userRepositoryCustomImpl.decreaseTickets(userId, amount)
+
+            verify { mongoTemplate.updateFirst(any<Query>(), any<Update>(), User::class.java) }
+        }
+
+        test("사용자가 존재하지 않거나 티켓이 부족할 때 UserTicketLackException을 발생시켜야 한다") {
+            val userId = ObjectId()
+            val amount = 5
+            val updateResult = mockk<UpdateResult>()
+
+            every { updateResult.matchedCount } returns 0L
+            every { mongoTemplate.updateFirst(any<Query>(), any<Update>(), User::class.java) } returns updateResult
+
+            shouldThrow<UserTicketLackException> {
+                userRepositoryCustomImpl.decreaseTickets(userId, amount)
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 🔎 작업 내용
- 펫 가챠 시스템을 구현하여 사용자가 티켓을 사용해 새로운 펫을 획득할 수 있는 기능 추가
- GachaException 베이스 클래스 및 상속 구조 구현
- MongoDB를 활용한 원자적 티켓 증감 시스템 구현
- 펫 가챠 API 엔드포인트 추가

## ➕ 기타
- Spring Data MongoDB Kotlin DSL 활용
- $inc 연산자를 통한 안전한 티켓 관리
- UpdateResult의 matchedCount를 활용한 예외 처리

close #230