### PR TITLE
fix: CI/CD 워크플로우 Docker 이미지 태그 변수 버그 수정

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -41,7 +41,7 @@ jobs:
       # Jib 빌드 및 푸시
       - name: Jib Build & Push
         env:
-          GITHUB_SHA: ${{ env.short_commit }}
+          GITHUB_SHA: ${{ env.full_commit }}
           DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
         run: |
           chmod +x ./gradlew


### PR DESCRIPTION
## 🔎 작업 내용
- `docker-build-push.yml`에서 `GITHUB_SHA` 환경변수를 존재하지 않는 `short_commit` 대신 `full_commit`으로 수정
- 이를 통해 `latest` + 커밋 해시 태그가 정상적으로 Docker Hub에 푸시됨

## ➕ 기타
- 

close #262