### PR TITLE
refactor: 응원하기 API 성능 개선

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation("org.springframework.security:spring-security-web")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
     implementation("com.google.firebase:firebase-admin:9.4.3")
+    implementation("org.springframework.retry:spring-retry")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("io.mockk:mockk:1.13.11")

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/DdanDdanServerApplication.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/DdanDdanServerApplication.kt
@@ -3,11 +3,13 @@ package notbe.tmtm.ddanddanserver
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableScheduling
+@EnableAsync
 class DdanDdanServerApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/CheerService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/CheerService.kt
@@ -25,6 +25,8 @@ class CheerService(
         cheererId: ObjectId,
         cheereeId: ObjectId,
     ): Cheer {
+        val cheeree = userRepository.findByIdOrThrow(cheereeId)
+        val cheerer = userRepository.findByIdOrThrow(cheererId)
         validateFriendship(cheererId, cheereeId)
 
         val cheer = Cheer.create(
@@ -34,9 +36,6 @@ class CheerService(
         )
 
         val result = cheerRepository.saveWithDuplicateCheck(cheer)
-
-        val cheeree = userRepository.findByIdOrThrow(cheereeId)
-        val cheerer = userRepository.findByIdOrThrow(cheererId)
         sendCheerMessage(cheeree.deviceToken, cheerer.name)
         return result
     }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/CheerService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/CheerService.kt
@@ -25,8 +25,6 @@ class CheerService(
         cheererId: ObjectId,
         cheereeId: ObjectId,
     ): Cheer {
-        val cheeree = userRepository.findByIdOrThrow(cheereeId)
-        val cheerer = userRepository.findByIdOrThrow(cheererId)
         validateFriendship(cheererId, cheereeId)
 
         val cheer = Cheer.create(
@@ -36,6 +34,9 @@ class CheerService(
         )
 
         val result = cheerRepository.saveWithDuplicateCheck(cheer)
+
+        val cheeree = userRepository.findByIdOrThrow(cheereeId)
+        val cheerer = userRepository.findByIdOrThrow(cheererId)
         sendCheerMessage(cheeree.deviceToken, cheerer.name)
         return result
     }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/CheerService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/CheerService.kt
@@ -1,14 +1,11 @@
 package notbe.tmtm.ddanddanserver.application.service
 
-import notbe.tmtm.ddanddanserver.domain.exception.CheerNotFriendsException
 import notbe.tmtm.ddanddanserver.domain.model.cheer.Cheer
 import notbe.tmtm.ddanddanserver.domain.model.notification.RoutingView
 import notbe.tmtm.ddanddanserver.domain.model.user.DeviceToken
 import notbe.tmtm.ddanddanserver.infrastructure.client.PushClient
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.CheerRepository
-import notbe.tmtm.ddanddanserver.infrastructure.database.repository.FriendshipRepository
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserRepository
-import notbe.tmtm.ddanddanserver.infrastructure.database.repository.areFriends
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.findByIdOrThrow
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Service
@@ -17,7 +14,6 @@ import java.time.LocalDate
 @Service
 class CheerService(
     private val cheerRepository: CheerRepository,
-    private val friendshipRepository: FriendshipRepository,
     private val userRepository: UserRepository,
     private val pushClient: PushClient,
 ) {
@@ -27,7 +23,6 @@ class CheerService(
     ): Cheer {
         val cheeree = userRepository.findByIdOrThrow(cheereeId)
         val cheerer = userRepository.findByIdOrThrow(cheererId)
-        validateFriendship(cheererId, cheereeId)
 
         val cheer = Cheer.create(
             cheererId = cheererId,
@@ -38,15 +33,6 @@ class CheerService(
         val result = cheerRepository.saveWithDuplicateCheck(cheer)
         sendCheerMessage(cheeree.deviceToken, cheerer.name)
         return result
-    }
-
-    private fun validateFriendship(
-        userId1: ObjectId,
-        userId2: ObjectId,
-    ) {
-        if (friendshipRepository.areFriends(userId1, userId2).not()) {
-            throw CheerNotFriendsException()
-        }
     }
 
     private fun sendCheerMessage(cheereeDeviceToken: DeviceToken?, cheererName: String?) {

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/config/RetryConfig.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/config/RetryConfig.kt
@@ -1,0 +1,17 @@
+package notbe.tmtm.ddanddanserver.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.retry.support.RetryTemplate
+
+@Configuration
+class RetryConfig {
+
+    @Bean
+    fun retryTemplate(): RetryTemplate {
+        return RetryTemplate.builder()
+            .maxAttempts(3)
+            .fixedBackoff(500)
+            .build()
+    }
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/exception/CheerException.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/exception/CheerException.kt
@@ -12,7 +12,3 @@ class CheerAlreadyExistsException(
 class CheerSelfException(
     data: Any? = null,
 ) : CheerException(ErrorCode.CHEER_SELF, data)
-
-class CheerNotFriendsException(
-    data: Any? = null,
-) : CheerException(ErrorCode.CHEER_NOT_FRIENDS, data)

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/exception/ErrorCode.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/exception/ErrorCode.kt
@@ -99,5 +99,4 @@ enum class ErrorCode(
      */
     CHEER_ALREADY_EXISTS("CE001", "해당 유저에 대해 이미 응원했습니다."),
     CHEER_SELF("CE002", "자기 자신을 응원할 수 없습니다."),
-    CHEER_NOT_FRIENDS("CE003", "친구가 아닌 사용자를 응원할 수 없습니다."),
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/client/FirebasePushClient.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/client/FirebasePushClient.kt
@@ -3,8 +3,10 @@ package notbe.tmtm.ddanddanserver.infrastructure.client
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.Message
 import com.google.firebase.messaging.Notification
+import notbe.tmtm.ddanddanserver.common.util.logger
 import notbe.tmtm.ddanddanserver.domain.model.notification.RoutingView
 import notbe.tmtm.ddanddanserver.domain.model.user.DeviceToken
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 
 private const val ROUTING_VIEW = "routingView"
@@ -14,6 +16,7 @@ class FirebasePushClient(
     private val fcmClient: FirebaseMessaging,
 ) : PushClient {
 
+    @Async
     override fun sendToMultiple(deviceTokens: List<DeviceToken?>, message: String, routingView: RoutingView) {
         if (deviceTokens.isEmpty()) return
 
@@ -32,16 +35,21 @@ class FirebasePushClient(
         fcmClient.sendEach(requests)
     }
 
+    @Async
     override fun sendToUser(deviceToken: DeviceToken?, message: String, routingView: RoutingView) {
         if (deviceToken?.isValid() != true) return
 
-        val request = Message
-            .builder()
-            .setToken(deviceToken.value)
-            .setNotification(Notification.builder().setBody(message).build())
-            .putData(ROUTING_VIEW, routingView.name)
-            .build()
+        try {
+            val request = Message
+                .builder()
+                .setToken(deviceToken.value)
+                .setNotification(Notification.builder().setBody(message).build())
+                .putData(ROUTING_VIEW, routingView.name)
+                .build()
 
-        fcmClient.send(request)
+            fcmClient.send(request)
+        } catch (e: Exception) {
+            logger().error("FCM 푸시 전송 실패", e)
+        }
     }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/client/FirebasePushClient.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/client/FirebasePushClient.kt
@@ -10,6 +10,8 @@ import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 
 private const val ROUTING_VIEW = "routingView"
+private const val MAX_RETRY_COUNT = 3
+private const val RETRY_DELAY_MS = 500L
 
 @Component
 class FirebasePushClient(
@@ -23,33 +25,44 @@ class FirebasePushClient(
         val requests = deviceTokens
             .filterNotNull()
             .filter { it.isValid() }
-            .map { token ->
-                Message
-                    .builder()
-                    .setToken(token.value)
-                    .setNotification(Notification.builder().setBody(message).build())
-                    .putData(ROUTING_VIEW, routingView.name)
-                    .build()
-            }
+            .map { token -> buildMessage(token.value, message, routingView) }
 
-        fcmClient.sendEach(requests)
+        executeWithRetry("sendToMultiple") {
+            fcmClient.sendEach(requests)
+        }
     }
 
     @Async
     override fun sendToUser(deviceToken: DeviceToken?, message: String, routingView: RoutingView) {
         if (deviceToken?.isValid() != true) return
 
-        try {
-            val request = Message
-                .builder()
-                .setToken(deviceToken.value)
-                .setNotification(Notification.builder().setBody(message).build())
-                .putData(ROUTING_VIEW, routingView.name)
-                .build()
+        val request = buildMessage(deviceToken.value, message, routingView)
 
+        executeWithRetry("sendToUser") {
             fcmClient.send(request)
-        } catch (e: Exception) {
-            logger().error("FCM 푸시 전송 실패", e)
         }
+    }
+
+    private fun buildMessage(token: String, message: String, routingView: RoutingView): Message =
+        Message
+            .builder()
+            .setToken(token)
+            .setNotification(Notification.builder().setBody(message).build())
+            .putData(ROUTING_VIEW, routingView.name)
+            .build()
+
+    private fun executeWithRetry(methodName: String, action: () -> Unit) {
+        repeat(MAX_RETRY_COUNT) { attempt ->
+            try {
+                action()
+                return
+            } catch (e: Exception) {
+                logger().warn("FCM $methodName 전송 실패 (시도 ${attempt + 1}/$MAX_RETRY_COUNT)", e)
+                if (attempt < MAX_RETRY_COUNT - 1) {
+                    Thread.sleep(RETRY_DELAY_MS)
+                }
+            }
+        }
+        logger().error("FCM $methodName 전송 최종 실패: ${MAX_RETRY_COUNT}회 재시도 후에도 실패")
     }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/client/FirebasePushClient.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/client/FirebasePushClient.kt
@@ -6,16 +6,16 @@ import com.google.firebase.messaging.Notification
 import notbe.tmtm.ddanddanserver.common.util.logger
 import notbe.tmtm.ddanddanserver.domain.model.notification.RoutingView
 import notbe.tmtm.ddanddanserver.domain.model.user.DeviceToken
+import org.springframework.retry.support.RetryTemplate
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 
 private const val ROUTING_VIEW = "routingView"
-private const val MAX_RETRY_COUNT = 3
-private const val RETRY_DELAY_MS = 500L
 
 @Component
 class FirebasePushClient(
     private val fcmClient: FirebaseMessaging,
+    private val retryTemplate: RetryTemplate,
 ) : PushClient {
 
     @Async
@@ -27,7 +27,7 @@ class FirebasePushClient(
             .filter { it.isValid() }
             .map { token -> buildMessage(token.value, message, routingView) }
 
-        executeWithRetry("sendToMultiple") {
+        retryTemplate.execute<Unit, Exception> {
             fcmClient.sendEach(requests)
         }
     }
@@ -38,7 +38,7 @@ class FirebasePushClient(
 
         val request = buildMessage(deviceToken.value, message, routingView)
 
-        executeWithRetry("sendToUser") {
+        retryTemplate.execute<Unit, Exception> {
             fcmClient.send(request)
         }
     }
@@ -50,19 +50,4 @@ class FirebasePushClient(
             .setNotification(Notification.builder().setBody(message).build())
             .putData(ROUTING_VIEW, routingView.name)
             .build()
-
-    private fun executeWithRetry(methodName: String, action: () -> Unit) {
-        repeat(MAX_RETRY_COUNT) { attempt ->
-            try {
-                action()
-                return
-            } catch (e: Exception) {
-                logger().warn("FCM $methodName 전송 실패 (시도 ${attempt + 1}/$MAX_RETRY_COUNT)", e)
-                if (attempt < MAX_RETRY_COUNT - 1) {
-                    Thread.sleep(RETRY_DELAY_MS)
-                }
-            }
-        }
-        logger().error("FCM $methodName 전송 최종 실패: ${MAX_RETRY_COUNT}회 재시도 후에도 실패")
-    }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/FriendshipRepository.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/FriendshipRepository.kt
@@ -23,6 +23,15 @@ interface FriendshipRepository : MongoRepository<Friendship, ObjectId> {
     fun deleteAllByInviterId(inviterId: ObjectId)
 
     fun deleteAllByInviteeId(inviteeId: ObjectId)
+
+    @Query(
+        value = "{ '\$or': [ " +
+            "{ 'inviterId': ?0, 'inviteeId': ?1, 'status': 'ACCEPTED' }, " +
+            "{ 'inviterId': ?1, 'inviteeId': ?0, 'status': 'ACCEPTED' } " +
+            "] }",
+        exists = true,
+    )
+    fun existsAcceptedFriendshipBetween(userId1: ObjectId, userId2: ObjectId): Boolean
 }
 
 fun FriendshipRepository.findByIdOrThrow(friendId: ObjectId): Friendship =
@@ -42,10 +51,7 @@ fun FriendshipRepository.findAcceptedFriends(userId: ObjectId): List<Friendship>
 fun FriendshipRepository.areFriends(
     userId1: ObjectId,
     userId2: ObjectId,
-): Boolean {
-    val friendship = findFriendshipBetween(userId1, userId2)
-    return friendship?.isAccepted() == true
-}
+): Boolean = existsAcceptedFriendshipBetween(userId1, userId2)
 
 fun FriendshipRepository.deleteAllBy(userId: ObjectId) {
     deleteAllByInviterId(userId)

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/CheerServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/CheerServiceTest.kt
@@ -69,21 +69,7 @@ class CheerServiceTest : FunSpec({
     test("친구가 아닌 사용자에게는 응원할 수 없다") {
         val cheererId = ObjectId()
         val cheereeId = ObjectId()
-        val cheereeUser = User(
-            id = cheereeId,
-            deviceToken = DeviceToken("test-token"),
-            name = "테스트유저",
-            setting = UserSetting(isAppPushOn = true)
-        )
-        val cheererUser = User(
-            id = cheererId,
-            deviceToken = DeviceToken("cheerer-token"),
-            name = "응원자",
-            setting = UserSetting(isAppPushOn = true)
-        )
 
-        every { userRepository.findByIdOrThrow(cheereeId) } returns cheereeUser
-        every { userRepository.findByIdOrThrow(cheererId) } returns cheererUser
         every { friendshipRepository.areFriends(cheererId, cheereeId) } returns false
 
         shouldThrow<CheerNotFriendsException> {
@@ -91,24 +77,20 @@ class CheerServiceTest : FunSpec({
         }
 
         verify { friendshipRepository.areFriends(cheererId, cheereeId) }
+        verify(exactly = 0) { userRepository.findByIdOrThrow(any()) }
         verify(exactly = 0) { cheerRepository.saveWithDuplicateCheck(any()) }
     }
 
     test("자기 자신을 응원하려고 하면 예외가 발생한다") {
         val userId = ObjectId()
-        val user = User(
-            id = userId,
-            deviceToken = DeviceToken("test-token"),
-            name = "테스트유저",
-            setting = UserSetting(isAppPushOn = true)
-        )
 
-        every { userRepository.findByIdOrThrow(userId) } returns user
         every { friendshipRepository.areFriends(userId, userId) } returns false
 
         shouldThrow<CheerNotFriendsException> {
             cheerService.createCheer(userId, userId)
         }
+
+        verify(exactly = 0) { userRepository.findByIdOrThrow(any()) }
     }
 
     test("중복 응원 시도 시 예외가 발생한다") {

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/CheerServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/CheerServiceTest.kt
@@ -7,35 +7,30 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import notbe.tmtm.ddanddanserver.domain.exception.CheerAlreadyExistsException
-import notbe.tmtm.ddanddanserver.domain.exception.CheerNotFriendsException
 import notbe.tmtm.ddanddanserver.domain.model.cheer.Cheer
 import notbe.tmtm.ddanddanserver.domain.model.user.DeviceToken
 import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.domain.model.user.UserSetting
 import notbe.tmtm.ddanddanserver.infrastructure.client.PushClient
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.CheerRepository
-import notbe.tmtm.ddanddanserver.infrastructure.database.repository.FriendshipRepository
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserRepository
-import notbe.tmtm.ddanddanserver.infrastructure.database.repository.areFriends
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.findByIdOrThrow
 import org.bson.types.ObjectId
 
 class CheerServiceTest : FunSpec({
     lateinit var cheerRepository: CheerRepository
-    lateinit var friendshipRepository: FriendshipRepository
     lateinit var userRepository: UserRepository
     lateinit var pushClient: PushClient
     lateinit var cheerService: CheerService
 
     beforeEach {
         cheerRepository = mockk()
-        friendshipRepository = mockk()
         userRepository = mockk()
         pushClient = mockk(relaxed = true)
-        cheerService = CheerService(cheerRepository, friendshipRepository, userRepository, pushClient)
+        cheerService = CheerService(cheerRepository, userRepository, pushClient)
     }
 
-    test("친구 관계에서 응원을 생성할 수 있다") {
+    test("응원을 생성할 수 있다") {
         val cheererId = ObjectId()
         val cheereeId = ObjectId()
         val expectedCheer = Cheer.create(cheererId, cheereeId)
@@ -54,61 +49,14 @@ class CheerServiceTest : FunSpec({
 
         every { userRepository.findByIdOrThrow(cheereeId) } returns cheereeUser
         every { userRepository.findByIdOrThrow(cheererId) } returns cheererUser
-        every { friendshipRepository.areFriends(cheererId, cheereeId) } returns true
         every { cheerRepository.saveWithDuplicateCheck(any()) } returns expectedCheer
 
         val result = cheerService.createCheer(cheererId, cheereeId)
 
         result.cheererId shouldBe cheererId
         result.cheereeId shouldBe cheereeId
-        verify { friendshipRepository.areFriends(cheererId, cheereeId) }
         verify { cheerRepository.saveWithDuplicateCheck(any()) }
         verify { pushClient.sendToUser(any(), any(), any()) }
-    }
-
-    test("친구가 아닌 사용자에게는 응원할 수 없다") {
-        val cheererId = ObjectId()
-        val cheereeId = ObjectId()
-        val cheereeUser = User(
-            id = cheereeId,
-            deviceToken = DeviceToken("test-token"),
-            name = "테스트유저",
-            setting = UserSetting(isAppPushOn = true)
-        )
-        val cheererUser = User(
-            id = cheererId,
-            deviceToken = DeviceToken("cheerer-token"),
-            name = "응원자",
-            setting = UserSetting(isAppPushOn = true)
-        )
-
-        every { userRepository.findByIdOrThrow(cheereeId) } returns cheereeUser
-        every { userRepository.findByIdOrThrow(cheererId) } returns cheererUser
-        every { friendshipRepository.areFriends(cheererId, cheereeId) } returns false
-
-        shouldThrow<CheerNotFriendsException> {
-            cheerService.createCheer(cheererId, cheereeId)
-        }
-
-        verify { friendshipRepository.areFriends(cheererId, cheereeId) }
-        verify(exactly = 0) { cheerRepository.saveWithDuplicateCheck(any()) }
-    }
-
-    test("자기 자신을 응원하려고 하면 예외가 발생한다") {
-        val userId = ObjectId()
-        val user = User(
-            id = userId,
-            deviceToken = DeviceToken("test-token"),
-            name = "테스트유저",
-            setting = UserSetting(isAppPushOn = true)
-        )
-
-        every { userRepository.findByIdOrThrow(userId) } returns user
-        every { friendshipRepository.areFriends(userId, userId) } returns false
-
-        shouldThrow<CheerNotFriendsException> {
-            cheerService.createCheer(userId, userId)
-        }
     }
 
     test("중복 응원 시도 시 예외가 발생한다") {
@@ -129,14 +77,12 @@ class CheerServiceTest : FunSpec({
 
         every { userRepository.findByIdOrThrow(cheereeId) } returns cheereeUser
         every { userRepository.findByIdOrThrow(cheererId) } returns cheererUser
-        every { friendshipRepository.areFriends(cheererId, cheereeId) } returns true
         every { cheerRepository.saveWithDuplicateCheck(any()) } throws CheerAlreadyExistsException()
 
         shouldThrow<CheerAlreadyExistsException> {
             cheerService.createCheer(cheererId, cheereeId)
         }
 
-        verify { friendshipRepository.areFriends(cheererId, cheereeId) }
         verify { cheerRepository.saveWithDuplicateCheck(any()) }
     }
 })

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/CheerServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/CheerServiceTest.kt
@@ -69,7 +69,21 @@ class CheerServiceTest : FunSpec({
     test("친구가 아닌 사용자에게는 응원할 수 없다") {
         val cheererId = ObjectId()
         val cheereeId = ObjectId()
+        val cheereeUser = User(
+            id = cheereeId,
+            deviceToken = DeviceToken("test-token"),
+            name = "테스트유저",
+            setting = UserSetting(isAppPushOn = true)
+        )
+        val cheererUser = User(
+            id = cheererId,
+            deviceToken = DeviceToken("cheerer-token"),
+            name = "응원자",
+            setting = UserSetting(isAppPushOn = true)
+        )
 
+        every { userRepository.findByIdOrThrow(cheereeId) } returns cheereeUser
+        every { userRepository.findByIdOrThrow(cheererId) } returns cheererUser
         every { friendshipRepository.areFriends(cheererId, cheereeId) } returns false
 
         shouldThrow<CheerNotFriendsException> {
@@ -77,20 +91,24 @@ class CheerServiceTest : FunSpec({
         }
 
         verify { friendshipRepository.areFriends(cheererId, cheereeId) }
-        verify(exactly = 0) { userRepository.findByIdOrThrow(any()) }
         verify(exactly = 0) { cheerRepository.saveWithDuplicateCheck(any()) }
     }
 
     test("자기 자신을 응원하려고 하면 예외가 발생한다") {
         val userId = ObjectId()
+        val user = User(
+            id = userId,
+            deviceToken = DeviceToken("test-token"),
+            name = "테스트유저",
+            setting = UserSetting(isAppPushOn = true)
+        )
 
+        every { userRepository.findByIdOrThrow(userId) } returns user
         every { friendshipRepository.areFriends(userId, userId) } returns false
 
         shouldThrow<CheerNotFriendsException> {
             cheerService.createCheer(userId, userId)
         }
-
-        verify(exactly = 0) { userRepository.findByIdOrThrow(any()) }
     }
 
     test("중복 응원 시도 시 예외가 발생한다") {

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/CheerControllerTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/CheerControllerTest.kt
@@ -7,7 +7,6 @@ import io.mockk.mockk
 import notbe.tmtm.ddanddanserver.application.service.CheerService
 import notbe.tmtm.ddanddanserver.common.WebExceptionHandler
 import notbe.tmtm.ddanddanserver.domain.exception.CheerAlreadyExistsException
-import notbe.tmtm.ddanddanserver.domain.exception.CheerNotFriendsException
 import notbe.tmtm.ddanddanserver.domain.exception.CheerSelfException
 import notbe.tmtm.ddanddanserver.domain.model.cheer.Cheer
 import org.bson.types.ObjectId
@@ -65,19 +64,6 @@ class CheerControllerTest : FunSpec({
                 .andExpect(jsonPath("$.cheereeId").value(testFriendId.toString()))
                 .andExpect(jsonPath("$.date").exists())
                 .andExpect(jsonPath("$.createdAt").exists())
-        }
-
-        test("친구가 아닌 경우 400 에러를 반환한다") {
-            // given
-            every { cheerService.createCheer(testUserId, testFriendId) } throws CheerNotFriendsException()
-
-            // when & then
-            mockMvc.perform(
-                post("/v1/cheers/{friendId}", testFriendId.toString())
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .principal(UsernamePasswordAuthenticationToken(testUserId.toString(), null, emptyList()))
-            )
-                .andExpect(status().isBadRequest)
         }
 
         test("자기 자신을 응원하려 할 때 400 에러를 반환한다") {


### PR DESCRIPTION
## 🔎 작업 내용
- FCM 푸시 알림을 `@Async` 비동기 처리로 변경하여 API 응답에서 FCM 네트워크 왕복 시간 제거
- FCM 전송 실패 시 최대 3회 재시도 로직 추가 (`sendToUser`, `sendToMultiple` 동일 적용)
- `areFriends()` 쿼리를 `$or` 조건 1회 조회로 통합 (기존 최대 2회 → 1회)
- 응원하기에서 불필요한 친구 확인 검증 로직 제거 (`CheerNotFriendsException` 및 에러코드 삭제)

## ➕ 기타
- `@EnableAsync` 추가로 `FirebasePushClient`의 `sendToUser`, `sendToMultiple` 모두 비동기 처리됨
- 비동기 처리 시 예외가 호출자에게 전파되지 않으므로 재시도 후 최종 실패 시 error 로그 기록

close #264