### PR TITLE
feat: 초대코드로 초대자 정보 조회 API 추가

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/FriendshipService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/FriendshipService.kt
@@ -6,6 +6,7 @@ import notbe.tmtm.ddanddanserver.domain.exception.FriendshipSelfAddException
 import notbe.tmtm.ddanddanserver.domain.exception.InviteCodeNotFoundException
 import notbe.tmtm.ddanddanserver.domain.model.friend.Friendship
 import notbe.tmtm.ddanddanserver.domain.model.notification.RoutingView
+import notbe.tmtm.ddanddanserver.domain.model.user.UserMainPet
 import notbe.tmtm.ddanddanserver.infrastructure.client.PushClient
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.FriendshipRepository
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.InviteCodeRepository
@@ -24,8 +25,20 @@ class FriendshipService(
     private val friendshipRepository: FriendshipRepository,
     private val inviteCodeRepository: InviteCodeRepository,
     private val userRepository: UserRepository,
+    private val userPetService: UserPetService,
     private val pushClient: PushClient
 ) {
+    @Transactional(readOnly = true)
+    fun getInviterByCode(
+        code: String,
+        userId: ObjectId,
+    ): UserMainPet {
+        val inviteCode = inviteCodeRepository.findByCode(code) ?: throw InviteCodeNotFoundException()
+        inviteCode.validateUse(userId)
+        val inviterId = inviteCode.getInviterId()
+        return userPetService.getUserMainPet(inviterId)
+    }
+
     @Transactional
     fun addFriendByInviteCode(
         code: String,

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/FriendController.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/FriendController.kt
@@ -8,6 +8,7 @@ import notbe.tmtm.ddanddanserver.application.service.UserPetService
 import notbe.tmtm.ddanddanserver.presentation.dto.response.FriendListResponse
 import notbe.tmtm.ddanddanserver.presentation.dto.response.FriendshipResponse
 import notbe.tmtm.ddanddanserver.presentation.dto.response.InviteCodeResponse
+import notbe.tmtm.ddanddanserver.presentation.dto.response.InviterResponse
 import org.bson.types.ObjectId
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -32,6 +33,17 @@ class FriendController(
 
         val inviteCode = inviteCodeService.generateInviteCode(userId)
         return InviteCodeResponse.fromDomain(inviteCode)
+    }
+
+    @GetMapping("/invite-codes/{code}")
+    @Operation(summary = "초대코드로 초대자 정보 조회", description = "초대코드를 사용하여 초대자 정보를 조회합니다. (친구 추가 없음)")
+    fun getInviterByCode(
+        @PathVariable code: String,
+        authentication: Authentication,
+    ): InviterResponse {
+        val userId = ObjectId(authentication.name)
+        val inviterUserMainPet = friendshipService.getInviterByCode(code, userId)
+        return InviterResponse.fromDomain(inviterUserMainPet)
     }
 
     @PostMapping("/by-invite/{code}")

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/FriendshipResponse.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/FriendshipResponse.kt
@@ -53,6 +53,19 @@ data class FriendUserInfo(
     }
 }
 
+@Schema(description = "초대자 정보 응답 DTO")
+data class InviterResponse(
+    @Schema(description = "초대자 사용자 정보")
+    val inviterUser: FriendUserInfo,
+) {
+    companion object {
+        fun fromDomain(userMainPet: UserMainPet): InviterResponse =
+            InviterResponse(
+                inviterUser = FriendUserInfo.fromDomain(userMainPet),
+            )
+    }
+}
+
 @Schema(description = "친구 목록 응답 DTO")
 data class FriendListResponse(
     @Schema(description = "친구 목록")


### PR DESCRIPTION
## 🔎 작업 내용
- 친구 추가 없이 초대코드로 초대자 정보만 조회하는 `GET /v1/friends/invite-codes/{code}` API 추가
- `FriendshipService.getInviterByCode()` 메서드 추가 (기존 조회/검증 로직 재사용)
- `InviterResponse` DTO 추가 (기존 `FriendUserInfo` 재사용)

## ➕ 기타
- iOS에서 딥링크로 초대코드를 받았을 때 친구 추가 전에 초대자 정보를 먼저 보여줄 수 있도록 합니다

close #266