### PR TITLE
chore: CodeRabbit 코드 리뷰 도입

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,47 @@
+# CodeRabbit 설정
+# 문서: https://docs.coderabbit.ai/guides/configure-coderabbit
+
+language: ko-KR
+early_access: false
+tone_instructions: "정중하고 명확한 한국어 존댓말로 리뷰합니다. 단정적인 단어는 피하고, 문제 지적 시 가능한 대안을 함께 제안합니다."
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - develop
+
+  path_filters:
+    - "!.claude/**"
+    - "!build/**"
+    - "!.gradle/**"
+    - "!**/*.lock"
+    - "!gradle/wrapper/**"
+
+  path_instructions:
+    - path: "src/main/kotlin/**/domain/**"
+      instructions: |
+        domain 레이어는 Spring/MongoDB 어노테이션이 들어가면 안 된다. 풍부 도메인 모델을 권장한다.
+    - path: "src/main/kotlin/**/application/**"
+      instructions: |
+        @Service + 생성자 주입 + val 컨벤션을 따르는지 확인한다. 트랜잭션 경계는 service에 둔다.
+    - path: "src/main/kotlin/**/infrastructure/database/**"
+      instructions: |
+        @Document 엔티티는 반드시 이 레이어에만 존재해야 한다. 도메인 모델 ↔ 엔티티 매핑이 빠지지 않았는지 확인한다.
+    - path: "src/main/kotlin/**/presentation/controller/**"
+      instructions: |
+        OpenAPI 어노테이션(@Operation, @Parameter, @ApiResponse, @Tag)이 누락되지 않았는지 확인한다. 비즈니스 로직은 service로 위임한다.
+    - path: "src/test/kotlin/**"
+      instructions: |
+        Kotest FunSpec + MockK 표준을 따른다. 테스트 이름은 한국어, assertion은 shouldBe/shouldThrow 등 Kotest DSL을 사용해야 한다 (assertEquals 사용 금지).
+
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -23,7 +23,10 @@ reviews:
     - "!.claude/**"
     - "!build/**"
     - "!.gradle/**"
-    - "!**/*.lock"
+    - "!**/gradle.lockfile"
+    - "!**/package-lock.json"
+    - "!**/yarn.lock"
+    - "!**/pnpm-lock.yaml"
     - "!gradle/wrapper/**"
 
   path_instructions:


### PR DESCRIPTION
## 🔎 작업 내용

PR 자동 코드 리뷰 도구 CodeRabbit을 도입한다.

### 추가
- `.coderabbit.yaml` — 레포 루트 설정 파일

### 주요 옵션
| 항목 | 값 | 비고 |
|---|---|---|
| 리뷰 언어 | `ko-KR` | 한국어 존댓말 |
| 톤 | `chill` | 부드러운 지적 |
| 자동 리뷰 | ✅ (`develop` 타겟 PR) | 드래프트는 제외 |
| 경로 제외 | `.claude/**`, `build/**`, `.gradle/**`, lock | 하네스/빌드 산출물 노이즈 차단 |
| `path_instructions` | 레이어별 가이드 | domain/application/infrastructure/presentation/test 각각 컨벤션 룰 주입 |

## ➕ 기타

**별도 진행 필요:** GitHub App 설치는 organization owner 권한이라 이 PR로 처리되지 않습니다. https://github.com/apps/coderabbitai 에서 `ddan-dda-ra/ddan-ddan-server`에 권한 부여해 주세요. 설치되면 이 PR에도 즉시 리뷰 코멘트가 달리는 형태로 동작 검증 가능합니다.

`path_instructions`는 레포 컨벤션을 그대로 반영했습니다 (도메인 레이어에 Spring 어노테이션 금지, OpenAPI 어노테이션 누락 검출, Kotest DSL 강제 등). 동작해 보고 노이즈가 많으면 후속 PR로 조정하시면 됩니다.

close #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review automation configuration to enhance development workflows and code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->