### PR TITLE
feat: 신규 가입 시 운영팀 디스코드 알림 추가

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEvent.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEvent.kt
@@ -1,0 +1,12 @@
+package notbe.tmtm.ddanddanserver.application.event
+
+import notbe.tmtm.ddanddanserver.domain.model.auth.OAuthType
+import org.bson.types.ObjectId
+import java.time.Instant
+
+data class UserRegisteredEvent(
+    val userId: ObjectId,
+    val nickName: String,
+    val oAuthType: OAuthType,
+    val registeredAt: Instant,
+)

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListener.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListener.kt
@@ -1,0 +1,49 @@
+package notbe.tmtm.ddanddanserver.application.event
+
+import notbe.tmtm.ddanddanserver.common.util.logger
+import notbe.tmtm.ddanddanserver.infrastructure.api.DiscordHookApi
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserRepository
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@Component
+class UserRegisteredEventListener(
+    private val userRepository: UserRepository,
+    private val discordHookApi: DiscordHookApi,
+    @Value("\${spring.profiles.active:local}") private val activeProfile: String,
+) {
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: UserRegisteredEvent) {
+        try {
+            val count = userRepository.count()
+            val phase = activeProfile.uppercase()
+            val registeredAtKst = "${KST_FORMATTER.format(event.registeredAt)} KST"
+            val body =
+                "[$phase] 신규 가입 | 닉네임=${event.nickName} | provider=${event.oAuthType} | " +
+                    "userId=${event.userId} | 가입시각=$registeredAtKst | " +
+                    "누적 가입자=${String.format("%,d", count)}명"
+
+            discordHookApi.sendMessage(DiscordHookApi.Request(content = body))
+        } catch (e: Exception) {
+            logger().error(
+                "Discord 신규 가입 알림 발송 실패: userId={}, provider={}",
+                event.userId,
+                event.oAuthType,
+                e,
+            )
+        }
+    }
+
+    companion object {
+        private val KST_FORMATTER: DateTimeFormatter =
+            DateTimeFormatter
+                .ofPattern("yyyy-MM-dd HH:mm:ss")
+                .withZone(ZoneId.of("Asia/Seoul"))
+    }
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/AuthService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/AuthService.kt
@@ -1,5 +1,6 @@
 package notbe.tmtm.ddanddanserver.application.service
 
+import notbe.tmtm.ddanddanserver.application.event.UserRegisteredEvent
 import notbe.tmtm.ddanddanserver.application.processor.OAuth
 import notbe.tmtm.ddanddanserver.application.processor.OAuthProcessorFactory
 import notbe.tmtm.ddanddanserver.common.JWTTokenProvider
@@ -9,9 +10,11 @@ import notbe.tmtm.ddanddanserver.domain.model.auth.OAuthType
 import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.AuthRepository
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserRepository
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
 
 @Service
 class AuthService(
@@ -19,6 +22,7 @@ class AuthService(
     private val userRepository: UserRepository,
     private val jwtTokenProvider: JWTTokenProvider,
     private val oauthProcessorFactory: OAuthProcessorFactory,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
     @Transactional
     fun login(
@@ -59,6 +63,14 @@ class AuthService(
             )
         authRepository.save(
             Auth.create(oAuthId = oAuth.id, type = oAuthType, userId = newUser.id),
+        )
+        eventPublisher.publishEvent(
+            UserRegisteredEvent(
+                userId = newUser.id,
+                nickName = oAuth.nickName,
+                oAuthType = oAuthType,
+                registeredAt = Instant.now(),
+            ),
         )
         return AuthResult(
             accessToken = jwtTokenProvider.createAccessToken(newUser),

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/api/ApiConfiguration.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/api/ApiConfiguration.kt
@@ -19,6 +19,15 @@ class ApiConfiguration {
     }
 
     @Bean
+    fun discordHookApi(
+        @Value("\${discord.hook-url}") hookUrl: String,
+    ): DiscordHookApi {
+        val factory = HttpServiceProxyFactory.builderFor(restClientAdapter(hookUrl)).build()
+
+        return factory.createClient(DiscordHookApi::class.java)
+    }
+
+    @Bean
     fun kakaoAuthApi(): KakaoAuthApi {
         val factory = HttpServiceProxyFactory.builderFor(restClientAdapter()).build()
 

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/api/DiscordHookApi.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/api/DiscordHookApi.kt
@@ -1,0 +1,23 @@
+package notbe.tmtm.ddanddanserver.infrastructure.api
+
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.service.annotation.HttpExchange
+import org.springframework.web.service.annotation.PostExchange
+
+@HttpExchange(accept = [MediaType.APPLICATION_JSON_VALUE])
+interface DiscordHookApi {
+    @PostExchange
+    fun sendMessage(
+        @RequestBody request: Request,
+    )
+
+    data class Request(
+        val content: String,
+        val username: String = DEFAULT_USERNAME,
+    )
+
+    companion object {
+        const val DEFAULT_USERNAME = "ddan-ddan-server-bot"
+    }
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -24,6 +24,9 @@ management:
 slack:
     hook-url: ${SLACK_WEBHOOK_URL}
 
+discord:
+    hook-url: ${DISCORD_WEBHOOK_URL}
+
 fcm:
     project-id: ${FCM_PROJECT_ID}
     key: ${FCM_KEY}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -24,6 +24,9 @@ management:
 slack:
     hook-url: ${SLACK_WEBHOOK_URL}
 
+discord:
+    hook-url: ${DISCORD_WEBHOOK_URL}
+
 fcm:
     project-id: ${FCM_PROJECT_ID}
     key: ${FCM_KEY}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -24,6 +24,9 @@ management:
 slack:
     hook-url: ${SLACK_WEBHOOK_URL}
 
+discord:
+    hook-url: ${DISCORD_WEBHOOK_URL}
+
 fcm:
     project-id: ${FCM_PROJECT_ID}
     key: ${FCM_KEY}

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListenerTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListenerTest.kt
@@ -1,0 +1,152 @@
+package notbe.tmtm.ddanddanserver.application.event
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import notbe.tmtm.ddanddanserver.domain.model.auth.OAuthType
+import notbe.tmtm.ddanddanserver.infrastructure.api.DiscordHookApi
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserRepository
+import org.bson.types.ObjectId
+import java.time.Instant
+
+class UserRegisteredEventListenerTest : FunSpec({
+    lateinit var userRepository: UserRepository
+    lateinit var discordHookApi: DiscordHookApi
+    lateinit var listener: UserRegisteredEventListener
+
+    fun newListener(activeProfile: String): UserRegisteredEventListener =
+        UserRegisteredEventListener(
+            userRepository = userRepository,
+            discordHookApi = discordHookApi,
+            activeProfile = activeProfile,
+        )
+
+    beforeEach {
+        userRepository = mockk()
+        discordHookApi = mockk(relaxed = true)
+        listener = newListener(activeProfile = "prod")
+    }
+
+    test("신규 가입 이벤트 수신 시 디스코드 웹훅에 정확한 페이로드로 발송한다") {
+        val userId = ObjectId()
+        val registeredAt = Instant.parse("2026-05-02T10:15:30Z")
+        val event =
+            UserRegisteredEvent(
+                userId = userId,
+                nickName = "홍길동",
+                oAuthType = OAuthType.KAKAO,
+                registeredAt = registeredAt,
+            )
+        every { userRepository.count() } returns 1234L
+        val captured = slot<DiscordHookApi.Request>()
+        every { discordHookApi.sendMessage(capture(captured)) } returns Unit
+
+        listener.handle(event)
+
+        verify(exactly = 1) { userRepository.count() }
+        verify(exactly = 1) { discordHookApi.sendMessage(any()) }
+
+        val content = captured.captured.content
+        content shouldContain "[PROD] 신규 가입"
+        content shouldContain "닉네임=홍길동"
+        content shouldContain "provider=KAKAO"
+        content shouldContain "userId=$userId"
+        content shouldContain "가입시각=2026-05-02 19:15:30 KST"
+        content shouldContain "누적 가입자=1,234명"
+    }
+
+    test("activeProfile이 소문자여도 메시지 접두어는 대문자로 변환된다") {
+        listener = newListener(activeProfile = "dev")
+
+        val event =
+            UserRegisteredEvent(
+                userId = ObjectId(),
+                nickName = "테스터",
+                oAuthType = OAuthType.APPLE,
+                registeredAt = Instant.parse("2026-01-01T00:00:00Z"),
+            )
+        every { userRepository.count() } returns 7L
+        val captured = slot<DiscordHookApi.Request>()
+        every { discordHookApi.sendMessage(capture(captured)) } returns Unit
+
+        listener.handle(event)
+
+        captured.captured.content shouldContain "[DEV] 신규 가입"
+        captured.captured.content shouldContain "provider=APPLE"
+        captured.captured.content shouldContain "누적 가입자=7명"
+    }
+
+    test("누적 가입자 수가 천 단위 이상이면 콤마가 포함된다") {
+        val event =
+            UserRegisteredEvent(
+                userId = ObjectId(),
+                nickName = "집계테스트",
+                oAuthType = OAuthType.KAKAO,
+                registeredAt = Instant.now(),
+            )
+        every { userRepository.count() } returns 1_234_567L
+        val captured = slot<DiscordHookApi.Request>()
+        every { discordHookApi.sendMessage(capture(captured)) } returns Unit
+
+        listener.handle(event)
+
+        captured.captured.content shouldContain "누적 가입자=1,234,567명"
+    }
+
+    test("디스코드 웹훅 호출이 예외를 던져도 리스너는 예외를 흡수한다") {
+        val event =
+            UserRegisteredEvent(
+                userId = ObjectId(),
+                nickName = "예외사용자",
+                oAuthType = OAuthType.KAKAO,
+                registeredAt = Instant.now(),
+            )
+        every { userRepository.count() } returns 10L
+        every { discordHookApi.sendMessage(any()) } throws RuntimeException("webhook down")
+
+        shouldNotThrow<Throwable> {
+            listener.handle(event)
+        }
+
+        verify(exactly = 1) { discordHookApi.sendMessage(any()) }
+    }
+
+    test("userRepository.count() 호출이 예외를 던져도 리스너는 예외를 흡수한다") {
+        val event =
+            UserRegisteredEvent(
+                userId = ObjectId(),
+                nickName = "DB장애",
+                oAuthType = OAuthType.APPLE,
+                registeredAt = Instant.now(),
+            )
+        every { userRepository.count() } throws RuntimeException("mongo down")
+
+        shouldNotThrow<Throwable> {
+            listener.handle(event)
+        }
+
+        verify(exactly = 0) { discordHookApi.sendMessage(any()) }
+    }
+
+    test("디스코드 요청의 username 필드는 기본값을 따른다") {
+        val event =
+            UserRegisteredEvent(
+                userId = ObjectId(),
+                nickName = "기본유저네임",
+                oAuthType = OAuthType.KAKAO,
+                registeredAt = Instant.now(),
+            )
+        every { userRepository.count() } returns 1L
+        val captured = slot<DiscordHookApi.Request>()
+        every { discordHookApi.sendMessage(capture(captured)) } returns Unit
+
+        listener.handle(event)
+
+        captured.captured.username shouldBe DiscordHookApi.DEFAULT_USERNAME
+    }
+})

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/AuthServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/AuthServiceTest.kt
@@ -1,0 +1,125 @@
+package notbe.tmtm.ddanddanserver.application.service
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import notbe.tmtm.ddanddanserver.application.event.UserRegisteredEvent
+import notbe.tmtm.ddanddanserver.application.processor.OAuth
+import notbe.tmtm.ddanddanserver.application.processor.OAuthProcessor
+import notbe.tmtm.ddanddanserver.application.processor.OAuthProcessorFactory
+import notbe.tmtm.ddanddanserver.common.JWTTokenProvider
+import notbe.tmtm.ddanddanserver.domain.model.auth.Auth
+import notbe.tmtm.ddanddanserver.domain.model.auth.OAuthType
+import notbe.tmtm.ddanddanserver.domain.model.user.DeviceToken
+import notbe.tmtm.ddanddanserver.domain.model.user.User
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.AuthRepository
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserRepository
+import org.bson.types.ObjectId
+import org.springframework.context.ApplicationEventPublisher
+import java.util.Optional
+
+class AuthServiceTest : FunSpec({
+    lateinit var authRepository: AuthRepository
+    lateinit var userRepository: UserRepository
+    lateinit var jwtTokenProvider: JWTTokenProvider
+    lateinit var oauthProcessorFactory: OAuthProcessorFactory
+    lateinit var eventPublisher: ApplicationEventPublisher
+    lateinit var oauthProcessor: OAuthProcessor
+    lateinit var authService: AuthService
+
+    beforeEach {
+        authRepository = mockk()
+        userRepository = mockk()
+        jwtTokenProvider = mockk()
+        oauthProcessorFactory = mockk()
+        eventPublisher = mockk(relaxed = true)
+        oauthProcessor = mockk()
+        authService =
+            AuthService(
+                authRepository = authRepository,
+                userRepository = userRepository,
+                jwtTokenProvider = jwtTokenProvider,
+                oauthProcessorFactory = oauthProcessorFactory,
+                eventPublisher = eventPublisher,
+            )
+
+        every { jwtTokenProvider.createAccessToken(any()) } returns "access-token"
+        every { jwtTokenProvider.createRefreshToken(any()) } returns "refresh-token"
+    }
+
+    test("신규 사용자 가입 시 UserRegisteredEvent가 발행된다") {
+        val oAuthAccessToken = "kakao-access"
+        val oAuth = OAuth(id = "oauth-id-1", type = OAuthType.KAKAO, nickName = "신규유저")
+
+        every { oauthProcessorFactory.getClient(OAuthType.KAKAO) } returns oauthProcessor
+        every { oauthProcessor.getOAuth(oAuthAccessToken) } returns oAuth
+        every { authRepository.findByOAuthIdAndType(oAuth.id, OAuthType.KAKAO) } returns null
+        every { userRepository.save(any<User>()) } answers { firstArg() }
+        every { authRepository.save(any<Auth>()) } answers { firstArg() }
+
+        val capturedEvent = slot<UserRegisteredEvent>()
+        every { eventPublisher.publishEvent(capture(capturedEvent)) } returns Unit
+
+        val result = authService.login(oAuthAccessToken, OAuthType.KAKAO, deviceToken = "device-1")
+
+        result.accessToken shouldBe "access-token"
+        result.refreshToken shouldBe "refresh-token"
+        result.user.name shouldBe "신규유저"
+
+        verify(exactly = 1) { eventPublisher.publishEvent(any<UserRegisteredEvent>()) }
+
+        capturedEvent.captured.nickName shouldBe "신규유저"
+        capturedEvent.captured.oAuthType shouldBe OAuthType.KAKAO
+        capturedEvent.captured.userId shouldBe result.user.id
+    }
+
+    test("기존 사용자 로그인 시 UserRegisteredEvent가 발행되지 않는다") {
+        val oAuthAccessToken = "kakao-access"
+        val oAuth = OAuth(id = "oauth-id-2", type = OAuthType.KAKAO, nickName = "기존유저")
+        val existingUserId = ObjectId()
+        val existingUser =
+            User(
+                id = existingUserId,
+                deviceToken = null,
+                name = "기존유저",
+            )
+        val existingAuth = Auth.create(oAuthId = oAuth.id, type = OAuthType.KAKAO, userId = existingUserId)
+
+        every { oauthProcessorFactory.getClient(OAuthType.KAKAO) } returns oauthProcessor
+        every { oauthProcessor.getOAuth(oAuthAccessToken) } returns oAuth
+        every { authRepository.findByOAuthIdAndType(oAuth.id, OAuthType.KAKAO) } returns existingAuth
+        every { userRepository.findById(existingUserId) } returns Optional.of(existingUser)
+        every { userRepository.save(any<User>()) } answers { firstArg() }
+
+        val result = authService.login(oAuthAccessToken, OAuthType.KAKAO, deviceToken = "new-device")
+
+        result.user.id shouldBe existingUserId
+        verify(exactly = 0) { eventPublisher.publishEvent(any<UserRegisteredEvent>()) }
+    }
+
+    test("기존 사용자가 동일한 deviceToken으로 로그인하면 사용자 저장이 호출되지 않는다") {
+        val oAuthAccessToken = "apple-access"
+        val oAuth = OAuth(id = "oauth-id-3", type = OAuthType.APPLE, nickName = "동일토큰유저")
+        val existingUserId = ObjectId()
+        val existingUser =
+            User(
+                id = existingUserId,
+                deviceToken = DeviceToken("same-token"),
+                name = "동일토큰유저",
+            )
+        val existingAuth = Auth.create(oAuthId = oAuth.id, type = OAuthType.APPLE, userId = existingUserId)
+
+        every { oauthProcessorFactory.getClient(OAuthType.APPLE) } returns oauthProcessor
+        every { oauthProcessor.getOAuth(oAuthAccessToken) } returns oAuth
+        every { authRepository.findByOAuthIdAndType(oAuth.id, OAuthType.APPLE) } returns existingAuth
+        every { userRepository.findById(existingUserId) } returns Optional.of(existingUser)
+
+        authService.login(oAuthAccessToken, OAuthType.APPLE, deviceToken = "same-token")
+
+        verify(exactly = 0) { userRepository.save(any<User>()) }
+        verify(exactly = 0) { eventPublisher.publishEvent(any<UserRegisteredEvent>()) }
+    }
+})


### PR DESCRIPTION
## 🔎 작업 내용

OAuth(Kakao/Apple) **신규 가입** 시 운영팀 디스코드 채널로 자동 알림 발송.

### 트리거 지점
- `AuthService.loginNewUser()` — 트랜잭션 안에서 `UserRegisteredEvent` 발행
- 기존 사용자 로그인은 알림 X

### 아키텍처
```
AuthService.loginNewUser()
  └─ ApplicationEventPublisher.publishEvent(UserRegisteredEvent)
      ↓ AFTER_COMMIT + @Async
     UserRegisteredEventListener.handle()
      ├─ userRepository.count()
      ├─ DiscordHookApi.sendMessage(content)
      └─ try/catch → logger.error  (재시도 없음, fire-and-forget)
```

- **AFTER_COMMIT** — 가입 트랜잭션 커밋 후에 발송, webhook 실패가 가입에 절대 전이되지 않음
- **@Async** — 별 쓰레드에서 실행해 OAuth 응답 지연 차단
- **누적 가입자 수** — listener에서 직접 `count()` 조회 (커밋 후라 신규 사용자 포함)

### 메시지 포맷
```
[PROD] 신규 가입 | 닉네임=홍길동 | provider=KAKAO | userId=66341a2b... | 가입시각=2026-05-03 19:23:11 KST | 누적 가입자=1,234명
```

- 단일 webhook URL + `spring.profiles.active`로 `[PROD]/[DEV]/[LOCAL]` 접두어 분기
- 가입시각은 **KST(Asia/Seoul)** 표기
- 천단위 콤마 적용

### 변경 파일 (10개)
**생성**
- `application/event/UserRegisteredEvent.kt`
- `application/event/UserRegisteredEventListener.kt`
- `infrastructure/api/DiscordHookApi.kt`
- 테스트 2개 (`UserRegisteredEventListenerTest`, `AuthServiceTest`)

**수정**
- `application/service/AuthService.kt` — 생성자 + `publishEvent` 1줄
- `infrastructure/api/ApiConfiguration.kt` — `discordHookApi` `@Bean`
- `application-{prod,dev,local}.yaml` — `discord.hook-url`

### 테스트
- Kotest `FunSpec` + MockK, **9/9 통과**
- 페이로드 정확성, KST 표기, phase 대문자 변환, 천단위 콤마, 예외 흡수 케이스 커버

## ⚠️ 머지 전 필수 작업

**환경변수 미등록 상태로 머지하면 Spring 부팅이 실패해 서비스가 다운됩니다.**

- [ ] Discord 운영팀 채널 생성
- [ ] 채널 설정 → 통합 → 웹후크 → 새 웹훅 발급 → URL 복사
- [ ] prod/dev 배포 환경에 `DISCORD_WEBHOOK_URL` 환경변수 등록
- [ ] (선택) dev/prod 분리하고 싶으면 yaml은 그대로 두고 환경변수만 다른 값으로 등록 — 현재 구조는 단일 webhook + phase 접두어로 채널 통합 가능

## ➕ 기타

- `SlackHookApi` 패턴을 1:1 미러링하되 payload 키는 Discord 스펙(`content`, `username`)에 맞춤
- `OAuth.nickName`은 Apple 로그인 시 이메일이라 PII 노출 지점 — Discord webhook 본문에는 그대로 노출, **`logger.error`에는 미포함** (PII 로깅 컨벤션 준수)
- 후속 PR 후보(이번 범위 외):
  - `SlackHookApi.username` 컨스턴트화 (현재 인라인 문자열)
  - `_workspace/`를 `.gitignore`에 추가

close #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 새 사용자 등록 시 Discord를 통해 가입 알림 발송 기능 추가
  * 사용자 등록 이벤트 기반 알림 시스템 구현
  * 누적 가입자 수를 포함한 상세 알림 메시지 전송

* **Chores**
  * Discord 웹훅 설정 추가 (개발, 로컬, 운영 환경)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->