### PR TITLE
fix: 신규 가입 디스코드 알림 미발송 (fallbackExecution)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -36,6 +36,8 @@ tools: Read, Grep, Glob, Bash
 - test-engineer가 정상 + 예외 케이스를 모두 커버했는가
 - mock 누락된 외부 의존
 - ./gradlew test가 통과하는가
+- **Spring 어노테이션이 동작 핵심인 코드(@Transactional, @TransactionalEventListener, @Async, @Scheduled, @EventListener, @Cacheable, AOP 어드바이스)에 통합 테스트가 같이 작성되었는가** — 단위 테스트만 있으면 어노테이션 동작이 0% 검증된다. PR #277 참조.
+- **`@TransactionalEventListener` 사용 시 트랜잭션 매니저 등록 여부 / `fallbackExecution` 설정 확인** — 단일 MongoDB 환경처럼 트랜잭션 매니저가 자동 등록되지 않는 경우 listener가 silent하게 dropping된다. 트랜잭션 매니저가 없거나 불확실하면 `fallbackExecution = true` 권장.
 
 ### 4. 보안
 - 인증이 필요한 엔드포인트에 JWT 필터가 적용되는가

--- a/.claude/skills/kotest-testing-patterns/SKILL.md
+++ b/.claude/skills/kotest-testing-patterns/SKILL.md
@@ -123,6 +123,70 @@ class FooIntegrationTest(
 - Repository 통합 테스트는 `@DataMongoTest` 활용 (이 레포의 기존 `*RepositoryImplTest` 참조)
 - Spring 컨텍스트 띄우는 통합 테스트는 비싸므로 신중히
 
+## Spring 어노테이션 핵심 코드는 통합 테스트 필수
+
+다음 어노테이션이 **동작의 핵심**인 코드는 **단위 테스트만으로는 절대 검증 불가** — 반드시 통합 테스트를 함께 작성한다:
+
+- `@Transactional`, `@TransactionalEventListener`
+- `@Async`, `@Scheduled`
+- `@EventListener`, `@Cacheable`
+- 그 외 Spring AOP가 처리하는 모든 어드바이스
+
+### 왜 단위 테스트로 안 되는가
+
+위 어노테이션들은 모두 **Spring AOP 프록시**가 처리한다. 테스트에서 `MyListener()`로 인스턴스를 직접 만들고 `listener.handle(event)`로 메서드를 직접 호출하면 프록시를 우회하므로 **어노테이션이 모두 무시되어 일반 함수 호출이 된다.** 메서드 본문 로직만 검증되고 어노테이션 동작(트랜잭션 경계, 비동기 실행, 이벤트 phase, fallbackExecution 등)은 0% 검증된다.
+
+### 실패 사례 (PR #277)
+
+`@TransactionalEventListener(phase = AFTER_COMMIT)`을 썼는데 단일 MongoDB 환경(`MongoTransactionManager` 미등록)에서 `@Transactional`이 NO-OP이 되어 listener가 silent하게 dropping. 단위 테스트는 listener를 직접 호출했기에 통과했고, 통합 테스트가 부재해 dev 배포 후에야 발견. `fallbackExecution = true` 추가로 핫픽스. (참조: `_workspace/05_review.md` 또는 git log)
+
+### 통합 테스트 패턴 — `@SpringJUnitConfig` 슬라이스
+
+`@SpringBootTest` 풀로 컨텍스트 띄우는 비용이 부담스러우면, 필요한 빈만 등록하는 좁은 슬라이스를 쓴다:
+
+```kotlin
+@SpringJUnitConfig(
+    classes = [
+        UserRegisteredEventListener::class,
+        UserRegisteredEventListenerIntegrationTest.TestConfig::class,
+    ]
+)
+@TestPropertySource(properties = ["spring.profiles.active=test"])
+class UserRegisteredEventListenerIntegrationTest {
+
+    @TestConfiguration
+    class TestConfig {
+        @Bean fun userRepository(): UserRepository = mockk()
+        @Bean fun discordHookApi(): DiscordHookApi = mockk(relaxed = true)
+    }
+
+    @Autowired lateinit var publisher: ApplicationEventPublisher
+    @Autowired lateinit var discordHookApi: DiscordHookApi
+
+    @Test
+    fun `이벤트 발행 시 listener가 실제로 호출된다`() {
+        every { /* ... */ } returns /* ... */
+        publisher.publishEvent(SomeEvent(...))
+        verify { discordHookApi.sendMessage(any()) }
+    }
+}
+```
+
+핵심:
+- **`@SpringJUnitConfig`**(JUnit5)로 좁은 컨텍스트, classes에 필요한 빈만 명시
+- 외부 의존(MongoDB, FCM, OAuth API 등)은 `@TestConfiguration` 안에서 `mockk()`로 빈 등록
+- `ApplicationEventPublisher` 주입 → `publishEvent` 호출 → mock이 호출됐는지 `verify`
+- **Kotest FunSpec이 아닌 JUnit5 형태 사용 OK** — 이 프로젝트는 Kotest Spring extension 의존성이 없음. 통합 테스트 한 케이스를 위해 의존성 추가하기보다 JUnit5로 작성하는 게 가벼움.
+
+### 단위 테스트 + 통합 테스트 분담
+
+| 테스트 유형 | 검증 대상 |
+|---|---|
+| 단위 테스트 (FunSpec, listener 직접 호출) | 메서드 본문 로직 (메시지 포맷, 분기, 예외 흡수) |
+| 통합 테스트 (@SpringJUnitConfig, publisher 호출) | 어노테이션 동작 (이벤트 wiring, fallbackExecution, 비동기 dispatch) |
+
+둘 다 작성한다. 단위만 있으면 함정에 빠진다.
+
 ## 테스트 위치
 
 production 코드의 패키지 구조를 그대로 미러링한다:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,3 +206,5 @@ EOF
 | 날짜 | 변경 내용 | 대상 | 사유 |
 |------|----------|------|------|
 | 2026-05-02 | 초기 구성 | 전체 | - |
+| 2026-05-03 | Spring 어노테이션 핵심 코드 통합 테스트 가이드 추가 | skills/kotest-testing-patterns | PR #277 사고 — `@TransactionalEventListener`가 단일 MongoDB 환경에서 silent dropping. 단위 테스트가 listener 직접 호출이라 잡지 못함. |
+| 2026-05-03 | 체크리스트 보강 (통합 테스트 누락 + `@TransactionalEventListener` + 트랜잭션 매니저 페어 점검) | agents/code-reviewer | 동일 사고 재발 방지 |

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListener.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListener.kt
@@ -18,7 +18,7 @@ class UserRegisteredEventListener(
     @Value("\${spring.profiles.active:local}") private val activeProfile: String,
 ) {
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     fun handle(event: UserRegisteredEvent) {
         try {
             val count = userRepository.count()

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListenerIntegrationTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListenerIntegrationTest.kt
@@ -1,0 +1,77 @@
+package notbe.tmtm.ddanddanserver.application.event
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import notbe.tmtm.ddanddanserver.domain.model.auth.OAuthType
+import notbe.tmtm.ddanddanserver.infrastructure.api.DiscordHookApi
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserRepository
+import org.bson.types.ObjectId
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.Bean
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+import java.time.Instant
+import kotlin.test.assertTrue
+
+/**
+ * 회귀 방지 통합 테스트.
+ *
+ * 단위 테스트(UserRegisteredEventListenerTest)는 listener.handle()을 직접 호출해
+ * @TransactionalEventListener · @Async 어노테이션 동작을 검증할 수 없다.
+ *
+ * 본 테스트는 Spring TestContext로 listener를 등록하고 ApplicationEventPublisher를
+ * 통해 이벤트를 발행하여, fallbackExecution = true 동작이 유지되는지 검증한다.
+ * 트랜잭션 매니저를 등록하지 않아 dev 환경(단일 MongoDB로 @Transactional이 NO-OP인 상황)을 그대로 시뮬레이션한다.
+ */
+@SpringJUnitConfig(
+    classes = [
+        UserRegisteredEventListener::class,
+        UserRegisteredEventListenerIntegrationTest.TestConfig::class,
+    ],
+)
+@TestPropertySource(properties = ["spring.profiles.active=test"])
+class UserRegisteredEventListenerIntegrationTest {
+    @TestConfiguration
+    class TestConfig {
+        @Bean
+        fun userRepository(): UserRepository = mockk()
+
+        @Bean
+        fun discordHookApi(): DiscordHookApi = mockk(relaxed = true)
+    }
+
+    @Autowired
+    lateinit var publisher: ApplicationEventPublisher
+
+    @Autowired
+    lateinit var userRepository: UserRepository
+
+    @Autowired
+    lateinit var discordHookApi: DiscordHookApi
+
+    @Test
+    fun `트랜잭션 매니저가 없는 환경에서도 publishEvent 후 listener가 호출되어 디스코드 웹훅이 발송된다`() {
+        every { userRepository.count() } returns 42L
+        val captured = slot<DiscordHookApi.Request>()
+        every { discordHookApi.sendMessage(capture(captured)) } returns Unit
+
+        publisher.publishEvent(
+            UserRegisteredEvent(
+                userId = ObjectId(),
+                nickName = "통합테스트사용자",
+                oAuthType = OAuthType.KAKAO,
+                registeredAt = Instant.now(),
+            ),
+        )
+
+        verify(exactly = 1) { discordHookApi.sendMessage(any()) }
+        assertTrue(captured.captured.content.contains("[TEST] 신규 가입"))
+        assertTrue(captured.captured.content.contains("provider=KAKAO"))
+        assertTrue(captured.captured.content.contains("누적 가입자=42명"))
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

신규 가입 디스코드 알림(#272)이 dev 환경에서 발송되지 않는 문제 핫픽스.

### 원인 (silent failure)
1. `AuthService.login()`은 `@Transactional` 적용
2. dev MongoDB가 **단일 인스턴스(SINGLE mode)** — replica set 아님
3. Spring Data MongoDB는 단일 인스턴스 환경에서 `MongoTransactionManager`를 자동 등록하지 **않음** → `@Transactional`이 사실상 NO-OP
4. `@TransactionalEventListener(phase = AFTER_COMMIT)`의 default `fallbackExecution = false` → 활성 트랜잭션이 없으면 listener를 **silent하게 dropping**

→ 이벤트는 발행되지만 listener 실행 안 됨, 에러 로그도 안 남음.

### 수정
`UserRegisteredEventListener`의 `@TransactionalEventListener`에 **`fallbackExecution = true`** 한 줄 추가:
- 트랜잭션 있을 땐 commit 후 실행
- 트랜잭션 없을 땐 즉시 실행
- 단일 MongoDB와 향후 replica set 환경 모두 안전

### 검증
- 컴파일/단위 테스트 통과 (기존 단위 테스트는 listener 메서드 직접 호출이라 어노테이션 동작과 무관 → 영향 없음)
- 머지 후 dev 재배포 → 가입 호출 → Discord 알림 도착 검증 예정

## ➕ 기타

### 단위 테스트가 왜 못 잡았는가
- `UserRegisteredEventListenerTest`는 `listener.handle(event)` 형태로 메서드를 직접 호출 → Spring AOP가 처리하는 `@TransactionalEventListener`/`@Async`가 무시됨
- `AuthServiceTest`는 `eventPublisher.publishEvent` 호출 횟수만 verify, 실제 listener 도달 여부는 검증 안 함
- 이런 함정은 `@SpringBootTest` 통합 테스트로만 잡힌다

### 후속 작업 (별도 PR)
1. `UserRegisteredEventListener`의 통합 테스트(@SpringBootTest 슬라이스) — 회귀 방지
2. 하네스 보강:
   - `kotest-testing-patterns`에 "Spring 어노테이션이 동작 핵심인 코드는 SpringBootTest 통합 테스트 필수" 가이드 추가
   - `code-reviewer` 체크리스트에 `@TransactionalEventListener` + 트랜잭션 매니저 페어 점검 추가

close #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)