### PR TITLE
chore: 디스코드 신규 가입 알림 메시지 포맷 개선 (Embed)

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListener.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListener.kt
@@ -1,6 +1,7 @@
 package notbe.tmtm.ddanddanserver.application.event
 
 import notbe.tmtm.ddanddanserver.common.util.logger
+import notbe.tmtm.ddanddanserver.domain.model.auth.OAuthType
 import notbe.tmtm.ddanddanserver.infrastructure.api.DiscordHookApi
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserRepository
 import org.springframework.beans.factory.annotation.Value
@@ -23,13 +24,8 @@ class UserRegisteredEventListener(
         try {
             val count = userRepository.count()
             val phase = activeProfile.uppercase()
-            val registeredAtKst = "${KST_FORMATTER.format(event.registeredAt)} KST"
-            val body =
-                "[$phase] 신규 가입 | 닉네임=${event.nickName} | provider=${event.oAuthType} | " +
-                    "userId=${event.userId} | 가입시각=$registeredAtKst | " +
-                    "누적 가입자=${String.format("%,d", count)}명"
-
-            discordHookApi.sendMessage(DiscordHookApi.Request(content = body))
+            val embed = buildEmbed(event, count, phase)
+            discordHookApi.sendMessage(DiscordHookApi.Request(embeds = listOf(embed)))
         } catch (e: Exception) {
             logger().error(
                 "Discord 신규 가입 알림 발송 실패: userId={}, provider={}",
@@ -39,6 +35,62 @@ class UserRegisteredEventListener(
             )
         }
     }
+
+    private fun buildEmbed(
+        event: UserRegisteredEvent,
+        count: Long,
+        phase: String,
+    ): DiscordHookApi.Embed {
+        val providerEmoji = providerEmoji(event.oAuthType)
+        val color = providerColor(event.oAuthType)
+        val phaseEmoji = phaseEmoji(phase)
+        val registeredAtKst = "${KST_FORMATTER.format(event.registeredAt)} KST"
+        val countFormatted = "%,d".format(count)
+
+        return DiscordHookApi.Embed(
+            title = "$providerEmoji 신규 가입",
+            description = milestoneText(count),
+            color = color,
+            fields =
+                listOf(
+                    DiscordHookApi.Field(name = "닉네임", value = event.nickName, inline = true),
+                    DiscordHookApi.Field(name = "Provider", value = event.oAuthType.name, inline = true),
+                    DiscordHookApi.Field(name = "User ID", value = "`${event.userId}`", inline = false),
+                    DiscordHookApi.Field(name = "가입 시각", value = registeredAtKst, inline = true),
+                    DiscordHookApi.Field(name = "누적 가입자", value = "${countFormatted}명", inline = true),
+                ),
+            footer = DiscordHookApi.Footer(text = "$phaseEmoji $phase · ddan-ddan-server"),
+            timestamp = event.registeredAt.toString(),
+        )
+    }
+
+    private fun providerEmoji(type: OAuthType): String =
+        when (type) {
+            OAuthType.KAKAO -> "🍫"
+            OAuthType.APPLE -> "🍎"
+        }
+
+    private fun providerColor(type: OAuthType): Int =
+        when (type) {
+            OAuthType.KAKAO -> 0xFEE500
+            OAuthType.APPLE -> 0x1C1C1E
+        }
+
+    private fun phaseEmoji(phase: String): String =
+        when (phase) {
+            "PROD" -> "🚀"
+            "DEV" -> "🧪"
+            else -> "💻"
+        }
+
+    private fun milestoneText(count: Long): String? =
+        when {
+            count <= 0L -> null
+            count % 1000L == 0L -> "🎉 ${"%,d".format(count)}명 달성!"
+            count % 500L == 0L -> "✨ ${"%,d".format(count)}명 달성!"
+            count % 100L == 0L -> "🎯 ${"%,d".format(count)}명 달성!"
+            else -> null
+        }
 
     companion object {
         private val KST_FORMATTER: DateTimeFormatter =

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/api/DiscordHookApi.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/api/DiscordHookApi.kt
@@ -1,5 +1,6 @@
 package notbe.tmtm.ddanddanserver.infrastructure.api
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.service.annotation.HttpExchange
@@ -12,9 +13,31 @@ interface DiscordHookApi {
         @RequestBody request: Request,
     )
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     data class Request(
-        val content: String,
         val username: String = DEFAULT_USERNAME,
+        val content: String? = null,
+        val embeds: List<Embed>? = null,
+    )
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    data class Embed(
+        val title: String? = null,
+        val description: String? = null,
+        val color: Int? = null,
+        val fields: List<Field>? = null,
+        val footer: Footer? = null,
+        val timestamp: String? = null,
+    )
+
+    data class Field(
+        val name: String,
+        val value: String,
+        val inline: Boolean = false,
+    )
+
+    data class Footer(
+        val text: String,
     )
 
     companion object {

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListenerIntegrationTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListenerIntegrationTest.kt
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
 import java.time.Instant
-import kotlin.test.assertTrue
+import kotlin.test.assertEquals
 
 /**
  * 회귀 방지 통합 테스트.
@@ -70,8 +70,10 @@ class UserRegisteredEventListenerIntegrationTest {
         )
 
         verify(exactly = 1) { discordHookApi.sendMessage(any()) }
-        assertTrue(captured.captured.content.contains("[TEST] 신규 가입"))
-        assertTrue(captured.captured.content.contains("provider=KAKAO"))
-        assertTrue(captured.captured.content.contains("누적 가입자=42명"))
+        val embed = captured.captured.embeds!!.first()
+        assertEquals("🍫 신규 가입", embed.title)
+        assertEquals("💻 TEST · ddan-ddan-server", embed.footer!!.text)
+        assertEquals("KAKAO", embed.fields!!.find { it.name == "Provider" }!!.value)
+        assertEquals("42명", embed.fields.find { it.name == "누적 가입자" }!!.value)
     }
 }

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListenerTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListenerTest.kt
@@ -32,7 +32,7 @@ class UserRegisteredEventListenerTest : FunSpec({
         listener = newListener(activeProfile = "prod")
     }
 
-    test("신규 가입 이벤트 수신 시 디스코드 웹훅에 정확한 페이로드로 발송한다") {
+    test("신규 가입 이벤트 수신 시 디스코드 웹훅에 embed로 발송한다") {
         val userId = ObjectId()
         val registeredAt = Instant.parse("2026-05-02T10:15:30Z")
         val event =
@@ -51,22 +51,26 @@ class UserRegisteredEventListenerTest : FunSpec({
         verify(exactly = 1) { userRepository.count() }
         verify(exactly = 1) { discordHookApi.sendMessage(any()) }
 
-        val content = captured.captured.content
-        content shouldContain "[PROD] 신규 가입"
-        content shouldContain "닉네임=홍길동"
-        content shouldContain "provider=KAKAO"
-        content shouldContain "userId=$userId"
-        content shouldContain "가입시각=2026-05-02 19:15:30 KST"
-        content shouldContain "누적 가입자=1,234명"
+        captured.captured.content shouldBe null
+        val embed = captured.captured.embeds!!.first()
+        embed.title shouldBe "🍫 신규 가입"
+        embed.color shouldBe 0xFEE500
+        embed.timestamp shouldBe registeredAt.toString()
+        embed.footer!!.text shouldBe "🚀 PROD · ddan-ddan-server"
+        embed.fields!!.find { it.name == "닉네임" }!!.value shouldBe "홍길동"
+        embed.fields.find { it.name == "Provider" }!!.value shouldBe "KAKAO"
+        embed.fields.find { it.name == "User ID" }!!.value shouldBe "`$userId`"
+        embed.fields.find { it.name == "가입 시각" }!!.value shouldBe "2026-05-02 19:15:30 KST"
+        embed.fields.find { it.name == "누적 가입자" }!!.value shouldBe "1,234명"
     }
 
-    test("activeProfile이 소문자여도 메시지 접두어는 대문자로 변환된다") {
+    test("APPLE provider는 다른 이모지와 색상을 사용한다") {
         listener = newListener(activeProfile = "dev")
 
         val event =
             UserRegisteredEvent(
                 userId = ObjectId(),
-                nickName = "테스터",
+                nickName = "tester@example.com",
                 oAuthType = OAuthType.APPLE,
                 registeredAt = Instant.parse("2026-01-01T00:00:00Z"),
             )
@@ -76,9 +80,65 @@ class UserRegisteredEventListenerTest : FunSpec({
 
         listener.handle(event)
 
-        captured.captured.content shouldContain "[DEV] 신규 가입"
-        captured.captured.content shouldContain "provider=APPLE"
-        captured.captured.content shouldContain "누적 가입자=7명"
+        val embed = captured.captured.embeds!!.first()
+        embed.title shouldBe "🍎 신규 가입"
+        embed.color shouldBe 0x1C1C1E
+        embed.footer!!.text shouldBe "🧪 DEV · ddan-ddan-server"
+        embed.fields!!.find { it.name == "Provider" }!!.value shouldBe "APPLE"
+        embed.fields.find { it.name == "누적 가입자" }!!.value shouldBe "7명"
+    }
+
+    test("누적 가입자가 100 단위 마일스톤이면 description에 표시된다") {
+        val event =
+            UserRegisteredEvent(
+                userId = ObjectId(),
+                nickName = "마일스톤",
+                oAuthType = OAuthType.KAKAO,
+                registeredAt = Instant.now(),
+            )
+        every { userRepository.count() } returns 100L
+        val captured = slot<DiscordHookApi.Request>()
+        every { discordHookApi.sendMessage(capture(captured)) } returns Unit
+
+        listener.handle(event)
+
+        captured.captured.embeds!!.first().description!! shouldContain "🎯"
+        captured.captured.embeds!!.first().description!! shouldContain "100명 달성"
+    }
+
+    test("누적 가입자가 1000 단위 마일스톤이면 description에 표시된다") {
+        val event =
+            UserRegisteredEvent(
+                userId = ObjectId(),
+                nickName = "큰마일스톤",
+                oAuthType = OAuthType.KAKAO,
+                registeredAt = Instant.now(),
+            )
+        every { userRepository.count() } returns 1000L
+        val captured = slot<DiscordHookApi.Request>()
+        every { discordHookApi.sendMessage(capture(captured)) } returns Unit
+
+        listener.handle(event)
+
+        captured.captured.embeds!!.first().description!! shouldContain "🎉"
+        captured.captured.embeds!!.first().description!! shouldContain "1,000명 달성"
+    }
+
+    test("일반 카운트는 description이 null이다") {
+        val event =
+            UserRegisteredEvent(
+                userId = ObjectId(),
+                nickName = "일반",
+                oAuthType = OAuthType.KAKAO,
+                registeredAt = Instant.now(),
+            )
+        every { userRepository.count() } returns 17L
+        val captured = slot<DiscordHookApi.Request>()
+        every { discordHookApi.sendMessage(capture(captured)) } returns Unit
+
+        listener.handle(event)
+
+        captured.captured.embeds!!.first().description shouldBe null
     }
 
     test("누적 가입자 수가 천 단위 이상이면 콤마가 포함된다") {
@@ -95,7 +155,9 @@ class UserRegisteredEventListenerTest : FunSpec({
 
         listener.handle(event)
 
-        captured.captured.content shouldContain "누적 가입자=1,234,567명"
+        captured.captured.embeds!!.first().fields!!
+            .find { it.name == "누적 가입자" }!!
+            .value shouldBe "1,234,567명"
     }
 
     test("디스코드 웹훅 호출이 예외를 던져도 리스너는 예외를 흡수한다") {


### PR DESCRIPTION
## 🔎 작업 내용

신규 가입 디스코드 알림(#272)의 메시지 포맷을 한 줄 텍스트에서 **Discord Embed**로 전환하여 가독성 개선.

### Before
\`\`\`
[DEV] 신규 가입 | 닉네임=MockKakao_... | provider=KAKAO | userId=... | 가입시각=... | 누적 가입자=15명
\`\`\`

### After
- 색상 바 (provider별)
- title에 provider 이모지
- fields에 inline 그리드 배치
- footer에 phase 정보
- 마일스톤 도달 시 description 강조

## 디자인 사양

| 요소 | 값 |
|---|---|
| **title** | `🍫 신규 가입` (KAKAO) / `🍎 신규 가입` (APPLE) |
| **color** | KAKAO `#FEE500` (카카오 옐로) / APPLE `#1C1C1E` (차콜) |
| **fields** | 닉네임 (inline), Provider (inline), User ID (full), 가입 시각 (inline), 누적 가입자 (inline) |
| **footer** | `🚀 PROD · ddan-ddan-server` / `🧪 DEV · ddan-ddan-server` / `💻 LOCAL · ...` |
| **timestamp** | `registeredAt` ISO 8601 (Discord가 사용자 로컬 시간으로 자동 표시) |
| **description** | 누적 가입자 100명 단위 마일스톤 도달 시: 🎯 100/500 ✨ / 1000 🎉 |

(KAKAO 이모지를 🍫로 한 이유: 카카오라는 단어의 어원이 cacao(카카오 콩)이라 카카오톡 로고가 표준 Unicode에 없는 상황에서 가장 직관적인 매핑. 사용자 시안 검토 완료.)

## 변경 파일 (4개)

| 파일 | 변경 |
|---|---|
| `infrastructure/api/DiscordHookApi.kt` | `Request.embeds` 추가, `Embed`/`Field`/`Footer` data class 신규, `@JsonInclude(NON_NULL)` |
| `application/event/UserRegisteredEventListener.kt` | content 대신 embed 조립. provider/phase/마일스톤 분기 함수 분리 |
| `application/event/UserRegisteredEventListenerTest.kt` | embed 검증 단위 테스트 9개로 확장 (이모지/색상/마일스톤/천단위/예외 흡수) |
| `application/event/UserRegisteredEventListenerIntegrationTest.kt` | embed 검증으로 갱신 |

## 검증

- ./gradlew test 통과
- 머지 전 webhook 직접 호출 시안으로 디자인 사용자 승인 완료
- 머지 후 dev 재배포 → 가입 호출 → embed 메시지 채널 도착 검증 예정

## ➕ 기타

- 본 PR은 listener의 출력 포맷만 변경. 트리거/이벤트/트랜잭션 동작은 그대로
- payload null 필드는 `@JsonInclude(NON_NULL)`로 직렬화에서 제외 → Discord 가 받는 JSON 깔끔
- 향후 다른 이벤트 알림(예: 비활성 사용자, 주간 랭킹)에 같은 Embed 인프라 재사용 가능

close #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)