### PR TITLE
chore: prod profile 적용 + JWT 토큰 만료 정정 + 로그 레벨 상향

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -12,8 +12,8 @@ app:
     jwt:
         secret: ${JWT_SECRET}
         expiration:
-            access-token: 604800
-            refresh-token: 2592000
+            access-token: 300000
+            refresh-token: 180
 
 management:
     endpoints:

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -12,8 +12,8 @@ app:
     jwt:
         secret: ${JWT_SECRET}
         expiration:
-            access-token: 300000
-            refresh-token: 180
+            access-token: 604800
+            refresh-token: 2592000
 
 management:
     endpoints:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -12,7 +12,7 @@ app:
     jwt:
         secret: ${JWT_SECRET}
         expiration:
-            access-token: 216000
+            access-token: 604800
             refresh-token: 2592000
 
 management:
@@ -36,7 +36,7 @@ fcm:
 
 logging:
   level:
-    root: WARN
+    root: INFO
     notbe.tmtm.ddanddanserver: INFO
     org.springframework: WARN
   pattern:


### PR DESCRIPTION
## 🔎 작업 내용

### 발견된 사실
prod 컨테이너가 default(`dev`) profile로 떠 있어 `application-prod.yaml`이 그동안 전혀 적용되지 않음. 또한 prod yaml 자체도 access-token 만료가 의도(1주일)와 다르게 2.5일로 적혀 있었음.

### 변경 (prod만)
| 파일 | 항목 | Before | After |
|---|---|---|---|
| application-prod.yaml | access-token 만료 | 216,000초 (2.5일) | **604,800초 (1주일)** |
| application-prod.yaml | logging.level.root | WARN | **INFO** |

dev yaml은 변경하지 않음 (사용자 결정).

## 별도 작업 (이번 PR 외 — 운영 디렉토리)

`~/HomeServer/ddan-ddan-server/prod/docker-compose.yml:10`의 `SPRING_PROFILES_ACTIVE=prod` 주석 해제 → 컨테이너 재시작.

이 작업이 함께 이뤄져야:
1. prod 컨테이너가 비로소 prod profile로 뜸 → `application-prod.yaml` 적용
2. prod yaml의 `mock-oauth.enabled: false` 적용 → **prod에 MockOAuthProcessor 활성화 위험 차단**
3. 위 토큰 만료 정정도 prod에 실제 반영
4. 로그 레벨/패턴(traceId 포함) 정상 적용

## 영향 / 호환성

- **JWT_SECRET**: 환경변수(prod/.env)에서 그대로 받으므로 변경 없음 → 기존 발급 토큰 그대로 살아있음
- **prod 토큰**: 2.5일 → 1주일 연장 (기존 발급된 access-token이 있으면 만료시간이 그대로 짧지만, 신규 발급분부터 1주일 적용)

## 검증 계획

1. PR 머지 → CI 빌드 → 새 이미지 푸시
2. `prod/docker-compose.yml` 주석 해제 + 컨테이너 재시작
3. 부팅 로그 확인:
   - `The following 1 profile is active: "prod"` ✅
   - `MockKakaoProcessor 활성화` WARN **미출력** (prod에 mock 미등록)
   - 새 로그 패턴(traceId/spanId 포함) 출력

close #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)