### PR TITLE
feat: 매월 1일 운영팀 디스코드에 전월 월간 랭킹 자동 발송

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/MonthlyRankingService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/MonthlyRankingService.kt
@@ -1,0 +1,133 @@
+package notbe.tmtm.ddanddanserver.application.service
+
+import notbe.tmtm.ddanddanserver.common.util.logger
+import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
+import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingCriteria
+import notbe.tmtm.ddanddanserver.infrastructure.api.DiscordHookApi
+import notbe.tmtm.ddanddanserver.infrastructure.database.entity.UserStatEntity
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserStatRepository
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+@Service
+class MonthlyRankingService(
+    private val userStatRepository: UserStatRepository,
+    private val discordHookApi: DiscordHookApi,
+    @Value("\${spring.profiles.active:local}") private val activeProfile: String,
+) {
+    fun sendPreviousMonthRanking() {
+        val today = LocalDate.now(ZoneId.of(KST))
+        val previousMonthStart = today.minusMonths(1).withDayOfMonth(1)
+        val previousMonthEnd = previousMonthStart.withDayOfMonth(previousMonthStart.lengthOfMonth())
+
+        val caloriesTop = userStatRepository.findRankingByDateRange(
+            RankingCriteria.TOTAL_CALORIES,
+            previousMonthStart,
+            previousMonthEnd,
+            TOP_N,
+        )
+        val succeededDaysTop = userStatRepository.findRankingByDateRange(
+            RankingCriteria.TOTAL_SUCCEEDED_DAYS,
+            previousMonthStart,
+            previousMonthEnd,
+            TOP_N,
+        )
+
+        val embeds = listOf(
+            buildCaloriesEmbed(caloriesTop, previousMonthStart),
+            buildSucceededDaysEmbed(succeededDaysTop, previousMonthStart),
+        )
+
+        try {
+            discordHookApi.sendMessage(DiscordHookApi.Request(embeds = embeds))
+        } catch (e: Exception) {
+            logger().error(
+                "월간 랭킹 디스코드 알림 발송 실패: month={}",
+                previousMonthStart.month,
+                e,
+            )
+        }
+    }
+
+    private fun buildCaloriesEmbed(
+        top: List<UserStatEntity>,
+        month: LocalDate,
+    ): DiscordHookApi.Embed =
+        DiscordHookApi.Embed(
+            title = "🔥 ${month.monthValue}월 칼로리 TOP $TOP_N",
+            color = COLOR_CALORIES,
+            description = top.toCaloriesDescription(),
+        )
+
+    private fun buildSucceededDaysEmbed(
+        top: List<UserStatEntity>,
+        month: LocalDate,
+    ): DiscordHookApi.Embed =
+        DiscordHookApi.Embed(
+            title = "🎯 ${month.monthValue}월 목표달성일 TOP $TOP_N",
+            color = COLOR_SUCCEEDED_DAYS,
+            description = top.toSucceededDaysDescription(),
+            footer = DiscordHookApi.Footer(text = footerText(month)),
+            timestamp = Instant.now().toString(),
+        )
+
+    private fun List<UserStatEntity>.toCaloriesDescription(): String {
+        if (isEmpty()) return "_지난 달 데이터가 없습니다._"
+        return mapIndexed { index, stat ->
+            "${medal(index)} **${stat.user.name ?: "(이름 없음)"}** — " +
+                "${"%,d".format(stat.totalCalories)} cal · " +
+                "달성 ${stat.totalSucceededDays}일 · " +
+                petLabel(stat)
+        }.joinToString("\n")
+    }
+
+    private fun List<UserStatEntity>.toSucceededDaysDescription(): String {
+        if (isEmpty()) return "_지난 달 데이터가 없습니다._"
+        return mapIndexed { index, stat ->
+            "${medal(index)} **${stat.user.name ?: "(이름 없음)"}** — " +
+                "${stat.totalSucceededDays}일 · " +
+                "${"%,d".format(stat.totalCalories)} cal · " +
+                petLabel(stat)
+        }.joinToString("\n")
+    }
+
+    private fun petLabel(stat: UserStatEntity): String =
+        "${stat.mainPet.type.toKorean()} Lv.${stat.mainPet.getLevel()}"
+
+    private fun PetType.toKorean(): String =
+        when (this) {
+            PetType.CAT -> "고양이"
+            PetType.HAMSTER -> "햄스터"
+            PetType.PENGUIN -> "펭귄"
+            PetType.DOG -> "강아지"
+            PetType.MOLE -> "두더지"
+        }
+
+    private fun medal(zeroBasedIndex: Int): String =
+        when (zeroBasedIndex) {
+            0 -> "🥇"
+            1 -> "🥈"
+            2 -> "🥉"
+            else -> "${zeroBasedIndex + 1}."
+        }
+
+    private fun footerText(month: LocalDate): String {
+        val phase = activeProfile.uppercase()
+        val phaseIcon = when (phase) {
+            "PROD" -> "🚀"
+            "DEV" -> "🧪"
+            else -> "💻"
+        }
+        return "$phaseIcon $phase · ${month.year}년 ${month.monthValue}월 월간 랭킹 · ddan-ddan-server"
+    }
+
+    companion object {
+        private const val TOP_N = 3
+        private const val KST = "Asia/Seoul"
+        private const val COLOR_CALORIES = 0xFF7F00
+        private const val COLOR_SUCCEEDED_DAYS = 0x57F287
+    }
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserStatRepository.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserStatRepository.kt
@@ -4,11 +4,19 @@ import notbe.tmtm.ddanddanserver.domain.model.ranking.PeriodType
 import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingCriteria
 import notbe.tmtm.ddanddanserver.domain.model.ranking.UserStat
 import notbe.tmtm.ddanddanserver.infrastructure.database.entity.UserStatEntity
+import java.time.LocalDate
 
 interface UserStatRepository {
     fun findAllRankingBy(
         criteria: RankingCriteria,
         periodType: PeriodType,
+    ): List<UserStatEntity>
+
+    fun findRankingByDateRange(
+        criteria: RankingCriteria,
+        startDate: LocalDate,
+        endDate: LocalDate,
+        limit: Int,
     ): List<UserStatEntity>
 }
 

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserStatRepositoryImpl.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserStatRepositoryImpl.kt
@@ -10,6 +10,7 @@ import org.springframework.data.mongodb.core.aggregation.Aggregation
 import org.springframework.data.mongodb.core.aggregation.ConditionalOperators.Cond
 import org.springframework.data.mongodb.core.query.Criteria
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 import kotlin.reflect.KProperty
 
 @Repository
@@ -34,6 +35,32 @@ class UserStatRepositoryImpl(
             lookupPet,
             Aggregation.unwind("main_pet", false),
             sort,
+        )
+        return mongoTemplate.aggregate(agg, DailyInfo::class.java, UserStatEntity::class.java)
+            .mappedResults
+    }
+
+    override fun findRankingByDateRange(
+        criteria: RankingCriteria,
+        startDate: LocalDate,
+        endDate: LocalDate,
+        limit: Int,
+    ): List<UserStatEntity> {
+        val matchCriteria = Aggregation.match(
+            Criteria
+                .where(DailyInfo::date.name)
+                .gte(startDate)
+                .lte(endDate),
+        )
+        val agg = Aggregation.newAggregation(
+            matchCriteria,
+            getGroupStage(),
+            getLookupUser(),
+            Aggregation.unwind("user", false),
+            getLookupPet(),
+            Aggregation.unwind("main_pet", false),
+            getSort(criteria),
+            Aggregation.limit(limit.toLong()),
         )
         return mongoTemplate.aggregate(agg, DailyInfo::class.java, UserStatEntity::class.java)
             .mappedResults

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/scheduler/MonthlyRankingScheduler.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/scheduler/MonthlyRankingScheduler.kt
@@ -1,0 +1,17 @@
+package notbe.tmtm.ddanddanserver.presentation.scheduler
+
+import notbe.tmtm.ddanddanserver.application.service.MonthlyRankingService
+import notbe.tmtm.ddanddanserver.common.util.logger
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class MonthlyRankingScheduler(
+    private val monthlyRankingService: MonthlyRankingService,
+) {
+    @Scheduled(cron = "0 5 0 1 * *", zone = "Asia/Seoul") // 매월 1일 00:05
+    fun sendPreviousMonthRanking() {
+        logger().info("월간 랭킹 발송 스케줄 시작")
+        monthlyRankingService.sendPreviousMonthRanking()
+    }
+}

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/MonthlyRankingServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/MonthlyRankingServiceTest.kt
@@ -1,0 +1,196 @@
+package notbe.tmtm.ddanddanserver.application.service
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import notbe.tmtm.ddanddanserver.domain.model.pet.Pet
+import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
+import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingCriteria
+import notbe.tmtm.ddanddanserver.domain.model.user.User
+import notbe.tmtm.ddanddanserver.domain.model.user.UserSetting
+import notbe.tmtm.ddanddanserver.infrastructure.api.DiscordHookApi
+import notbe.tmtm.ddanddanserver.infrastructure.database.entity.UserStatEntity
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserStatRepository
+import org.bson.types.ObjectId
+
+class MonthlyRankingServiceTest : FunSpec({
+    lateinit var userStatRepository: UserStatRepository
+    lateinit var discordHookApi: DiscordHookApi
+    lateinit var service: MonthlyRankingService
+
+    fun newService(activeProfile: String): MonthlyRankingService =
+        MonthlyRankingService(
+            userStatRepository = userStatRepository,
+            discordHookApi = discordHookApi,
+            activeProfile = activeProfile,
+        )
+
+    fun userStat(
+        name: String,
+        totalCalories: Int,
+        totalSucceededDays: Int,
+        petType: PetType,
+        petExp: Int,
+    ): UserStatEntity =
+        UserStatEntity(
+            user = User(
+                id = ObjectId(),
+                deviceToken = null,
+                name = name,
+                setting = UserSetting(),
+            ),
+            mainPet = Pet(
+                id = ObjectId(),
+                type = petType,
+                ownerUserId = ObjectId(),
+                exp = petExp,
+            ),
+            totalCalories = totalCalories,
+            totalSucceededDays = totalSucceededDays,
+        )
+
+    beforeEach {
+        userStatRepository = mockk()
+        discordHookApi = mockk(relaxed = true)
+        service = newService(activeProfile = "prod")
+    }
+
+    test("두 카테고리 TOP 3을 조회하여 디스코드에 2개 embed로 발송한다") {
+        val caloriesTop = listOf(
+            userStat("하드윤", 9172, 2, PetType.MOLE, 2700),
+            userStat("맨정신", 9080, 17, PetType.MOLE, 3900),
+            userStat("성민쓰", 8083, 16, PetType.DOG, 8000),
+        )
+        val daysTop = listOf(
+            userStat("맨정신", 9080, 17, PetType.MOLE, 3900),
+            userStat("성민쓰", 8083, 16, PetType.DOG, 8000),
+            userStat("아이보리", 4214, 12, PetType.MOLE, 3500),
+        )
+        every {
+            userStatRepository.findRankingByDateRange(RankingCriteria.TOTAL_CALORIES, any(), any(), 3)
+        } returns caloriesTop
+        every {
+            userStatRepository.findRankingByDateRange(RankingCriteria.TOTAL_SUCCEEDED_DAYS, any(), any(), 3)
+        } returns daysTop
+        val captured = slot<DiscordHookApi.Request>()
+        every { discordHookApi.sendMessage(capture(captured)) } returns Unit
+
+        service.sendPreviousMonthRanking()
+
+        verify(exactly = 1) { discordHookApi.sendMessage(any()) }
+        captured.captured.embeds!!.size shouldBe 2
+
+        val caloriesEmbed = captured.captured.embeds!![0]
+        caloriesEmbed.title!! shouldContain "🔥"
+        caloriesEmbed.title!! shouldContain "칼로리 TOP 3"
+        caloriesEmbed.color shouldBe 0xFF7F00
+        caloriesEmbed.description!! shouldContain "🥇 **하드윤** — 9,172 cal · 달성 2일 · 두더지 Lv.4"
+        caloriesEmbed.description!! shouldContain "🥈 **맨정신**"
+        caloriesEmbed.description!! shouldContain "🥉 **성민쓰**"
+
+        val daysEmbed = captured.captured.embeds!![1]
+        daysEmbed.title!! shouldContain "🎯"
+        daysEmbed.title!! shouldContain "목표달성일 TOP 3"
+        daysEmbed.color shouldBe 0x57F287
+        daysEmbed.description!! shouldContain "🥇 **맨정신** — 17일 · 9,080 cal · 두더지 Lv.4"
+        daysEmbed.description!! shouldContain "🥉 **아이보리** — 12일 · 4,214 cal · 두더지 Lv.4"
+    }
+
+    test("PROD profile은 footer에 🚀 PROD 접두어를 표시한다") {
+        every { userStatRepository.findRankingByDateRange(any(), any(), any(), any()) } returns emptyList()
+        val captured = slot<DiscordHookApi.Request>()
+        every { discordHookApi.sendMessage(capture(captured)) } returns Unit
+
+        service.sendPreviousMonthRanking()
+
+        captured.captured.embeds!![1].footer!!.text shouldContain "🚀 PROD ·"
+        captured.captured.embeds!![1].footer!!.text shouldContain "월간 랭킹 · ddan-ddan-server"
+    }
+
+    test("DEV profile은 footer에 🧪 DEV 접두어를 표시한다") {
+        service = newService(activeProfile = "dev")
+        every { userStatRepository.findRankingByDateRange(any(), any(), any(), any()) } returns emptyList()
+        val captured = slot<DiscordHookApi.Request>()
+        every { discordHookApi.sendMessage(capture(captured)) } returns Unit
+
+        service.sendPreviousMonthRanking()
+
+        captured.captured.embeds!![1].footer!!.text shouldContain "🧪 DEV ·"
+    }
+
+    test("그 외 profile은 footer에 💻 접두어를 표시한다") {
+        service = newService(activeProfile = "test")
+        every { userStatRepository.findRankingByDateRange(any(), any(), any(), any()) } returns emptyList()
+        val captured = slot<DiscordHookApi.Request>()
+        every { discordHookApi.sendMessage(capture(captured)) } returns Unit
+
+        service.sendPreviousMonthRanking()
+
+        captured.captured.embeds!![1].footer!!.text shouldContain "💻 TEST ·"
+    }
+
+    test("모든 펫 타입은 한국어로 표기된다") {
+        val sample = listOf(
+            userStat("a", 100, 1, PetType.CAT, 0),
+            userStat("b", 100, 1, PetType.HAMSTER, 0),
+            userStat("c", 100, 1, PetType.PENGUIN, 0),
+        )
+        every {
+            userStatRepository.findRankingByDateRange(RankingCriteria.TOTAL_CALORIES, any(), any(), 3)
+        } returns sample
+        every {
+            userStatRepository.findRankingByDateRange(RankingCriteria.TOTAL_SUCCEEDED_DAYS, any(), any(), 3)
+        } returns emptyList()
+        val captured = slot<DiscordHookApi.Request>()
+        every { discordHookApi.sendMessage(capture(captured)) } returns Unit
+
+        service.sendPreviousMonthRanking()
+
+        val desc = captured.captured.embeds!![0].description!!
+        desc shouldContain "고양이"
+        desc shouldContain "햄스터"
+        desc shouldContain "펭귄"
+    }
+
+    test("데이터가 없으면 description에 안내 문구가 들어간다") {
+        every { userStatRepository.findRankingByDateRange(any(), any(), any(), any()) } returns emptyList()
+        val captured = slot<DiscordHookApi.Request>()
+        every { discordHookApi.sendMessage(capture(captured)) } returns Unit
+
+        service.sendPreviousMonthRanking()
+
+        captured.captured.embeds!![0].description!! shouldContain "지난 달 데이터가 없습니다"
+        captured.captured.embeds!![1].description!! shouldContain "지난 달 데이터가 없습니다"
+    }
+
+    test("디스코드 호출이 예외를 던져도 서비스는 예외를 흡수한다") {
+        every { userStatRepository.findRankingByDateRange(any(), any(), any(), any()) } returns emptyList()
+        every { discordHookApi.sendMessage(any()) } throws RuntimeException("webhook down")
+
+        shouldNotThrow<Throwable> {
+            service.sendPreviousMonthRanking()
+        }
+    }
+
+    test("두 카테고리에 대해 직전 달 1일~말일을 조회한다") {
+        val startSlot = slot<java.time.LocalDate>()
+        val endSlot = slot<java.time.LocalDate>()
+        every {
+            userStatRepository.findRankingByDateRange(any(), capture(startSlot), capture(endSlot), 3)
+        } returns emptyList()
+
+        service.sendPreviousMonthRanking()
+
+        startSlot.captured.dayOfMonth shouldBe 1
+        endSlot.captured.dayOfMonth shouldBe startSlot.captured.lengthOfMonth()
+        startSlot.captured.month shouldBe endSlot.captured.month
+        startSlot.captured.year shouldBe endSlot.captured.year
+        startSlot.captured.month shouldNotBe java.time.LocalDate.now(java.time.ZoneId.of("Asia/Seoul")).month
+    }
+})

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/scheduler/MonthlyRankingSchedulerIntegrationTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/scheduler/MonthlyRankingSchedulerIntegrationTest.kt
@@ -1,0 +1,91 @@
+package notbe.tmtm.ddanddanserver.presentation.scheduler
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import notbe.tmtm.ddanddanserver.application.service.MonthlyRankingService
+import notbe.tmtm.ddanddanserver.domain.model.ranking.RankingCriteria
+import notbe.tmtm.ddanddanserver.infrastructure.api.DiscordHookApi
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserStatRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * 회귀 방지 통합 테스트.
+ *
+ * 단위 테스트(MonthlyRankingServiceTest)는 service를 직접 호출해
+ * scheduler→service wiring과 Spring 빈 등록을 검증할 수 없다.
+ *
+ * 본 테스트는 Spring TestContext로 Scheduler + Service + 의존 mock을 등록하고
+ * scheduler.sendPreviousMonthRanking()을 호출하여 전체 흐름이 동작하는지 검증한다.
+ *
+ * @Scheduled의 cron 트리거 자체(매월 1일 00:05 KST)는 시간 조작이 필요해 통합 테스트로
+ * 검증이 비현실적이므로, production 운영으로 검증.
+ */
+@SpringJUnitConfig(
+    classes = [
+        MonthlyRankingScheduler::class,
+        MonthlyRankingService::class,
+        MonthlyRankingSchedulerIntegrationTest.TestConfig::class,
+    ],
+)
+@TestPropertySource(properties = ["spring.profiles.active=test"])
+class MonthlyRankingSchedulerIntegrationTest {
+    @TestConfiguration
+    class TestConfig {
+        @Bean
+        fun userStatRepository(): UserStatRepository = mockk(relaxed = true)
+
+        @Bean
+        fun discordHookApi(): DiscordHookApi = mockk(relaxed = true)
+    }
+
+    @Autowired
+    lateinit var scheduler: MonthlyRankingScheduler
+
+    @Autowired
+    lateinit var userStatRepository: UserStatRepository
+
+    @Autowired
+    lateinit var discordHookApi: DiscordHookApi
+
+    @Test
+    fun `Spring 컨텍스트에서 scheduler 트리거 시 service-repository-discord 호출 흐름이 동작한다`() {
+        every {
+            userStatRepository.findRankingByDateRange(any(), any(), any(), any())
+        } returns emptyList()
+        val captured = slot<DiscordHookApi.Request>()
+        every { discordHookApi.sendMessage(capture(captured)) } returns Unit
+
+        scheduler.sendPreviousMonthRanking()
+
+        verify(exactly = 1) {
+            userStatRepository.findRankingByDateRange(
+                RankingCriteria.TOTAL_CALORIES,
+                any(),
+                any(),
+                3,
+            )
+        }
+        verify(exactly = 1) {
+            userStatRepository.findRankingByDateRange(
+                RankingCriteria.TOTAL_SUCCEEDED_DAYS,
+                any(),
+                any(),
+                3,
+            )
+        }
+        verify(exactly = 1) { discordHookApi.sendMessage(any()) }
+
+        // wiring + phase 주입까지 동작하는지 확인
+        assertEquals(2, captured.captured.embeds!!.size)
+        assertTrue(captured.captured.embeds!![1].footer!!.text.contains("TEST"))
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

매월 1일 00:05 KST에 전월 월간 랭킹(칼로리·목표달성일 각 TOP 3)을 운영팀 디스코드 채널로 자동 발송. 추출 데이터: 닉네임 · 칼로리 · 달성일 · 메인펫 종류 · 메인펫 레벨.

### 트리거
```kotlin
@Scheduled(cron = "0 5 0 1 * *", zone = "Asia/Seoul")
```

### 메시지 포맷 (사용자 시안 승인)
2 embeds:
- **🔥 칼로리 TOP 3** (주황 #FF7F00)
- **🎯 목표달성일 TOP 3** (초록 #57F287)

각 항목: `🥇 **닉네임** — 9,172 cal · 달성 2일 · 두더지 Lv.4`
- 펫 한국어 표기: 고양이/햄스터/펭귄/강아지/두더지
- footer: `{phaseIcon} {PHASE} · YYYY년 M월 월간 랭킹 · ddan-ddan-server` (🚀 PROD / 🧪 DEV / 💻 그 외)

### 변경 파일 (5개)
**신규**
- `application/service/MonthlyRankingService.kt` — 추출 + embed 조립 + Discord 호출
- `presentation/scheduler/MonthlyRankingScheduler.kt` — cron 트리거
- `application/service/MonthlyRankingServiceTest.kt` — Kotest 단위 테스트 8개

**수정**
- `infrastructure/database/repository/UserStatRepository(.kt|Impl.kt)` — `findRankingByDateRange(criteria, start, end, limit)` 메서드 추가
  - 기존 `findAllRankingBy(criteria, periodType)`은 PeriodType의 현재 기간만 사용해서 전월 추출 불가 → 임의 date range + limit 받는 신규 메서드

### 안정성
- 디스코드 호출 실패는 try/catch로 흡수 (fire-and-forget)
- 신규 가입 알림과 같은 webhook 인프라 재사용
- 데이터 없을 시 "지난 달 데이터가 없습니다" 안내 문구 (예외 미발생)

### 테스트
- Kotest FunSpec + MockK 단위 테스트 8개
  - 두 카테고리 정상 발송
  - phase별 footer 분기 (PROD/DEV/그 외)
  - 펫 5종 한국어 표기
  - 직전 달 계산 (1일~말일, 현재 달과 다른 달)
  - 데이터 없을 때 안내
  - 디스코드 예외 흡수
- 통합 테스트는 본 PR 범위 외:
  - `@Scheduled`의 cron 트리거 자체는 통합 테스트가 비현실적(시간 조작 필요) → production 운영으로 검증
  - service.sendPreviousMonthRanking()은 plain function이라 단위 테스트로 충분

## ➕ 기타

- 4월 데이터로 사전 추출 1회 + 시안 3종 사용자 확정 완료 (대화 컨텍스트)
- prod 배포 후 첫 발송은 2026년 6월 1일 00:05 KST (5월 데이터)
  - 더 빠른 검증이 필요하면 PR 머지 후 dev에서 cron을 임시 5분 단위로 바꿔 테스트 가능 (별도 작업)

close #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 월별 랭킹 기능 추가

* **New Features**
  * 매월 1일 자동으로 이전 달 랭킹을 Discord에 전송
  * 총 칼로리 및 성공 일수 기준으로 상위 사용자 순위 표시
  * 메달 아이콘, 사용자명, 칼로리, 성공 일수, 펫 정보 포함하여 형식화된 랭킹 보고서 제공

* **Tests**
  * 월별 랭킹 서비스 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->