### PR TITLE
chore: 월간 랭킹 발송 메서드 전체 try/catch로 확장

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/MonthlyRankingService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/MonthlyRankingService.kt
@@ -23,29 +23,29 @@ class MonthlyRankingService(
         val previousMonthStart = today.minusMonths(1).withDayOfMonth(1)
         val previousMonthEnd = previousMonthStart.withDayOfMonth(previousMonthStart.lengthOfMonth())
 
-        val caloriesTop = userStatRepository.findRankingByDateRange(
-            RankingCriteria.TOTAL_CALORIES,
-            previousMonthStart,
-            previousMonthEnd,
-            TOP_N,
-        )
-        val succeededDaysTop = userStatRepository.findRankingByDateRange(
-            RankingCriteria.TOTAL_SUCCEEDED_DAYS,
-            previousMonthStart,
-            previousMonthEnd,
-            TOP_N,
-        )
-
-        val embeds = listOf(
-            buildCaloriesEmbed(caloriesTop, previousMonthStart),
-            buildSucceededDaysEmbed(succeededDaysTop, previousMonthStart),
-        )
-
         try {
+            val caloriesTop = userStatRepository.findRankingByDateRange(
+                RankingCriteria.TOTAL_CALORIES,
+                previousMonthStart,
+                previousMonthEnd,
+                TOP_N,
+            )
+            val succeededDaysTop = userStatRepository.findRankingByDateRange(
+                RankingCriteria.TOTAL_SUCCEEDED_DAYS,
+                previousMonthStart,
+                previousMonthEnd,
+                TOP_N,
+            )
+
+            val embeds = listOf(
+                buildCaloriesEmbed(caloriesTop, previousMonthStart),
+                buildSucceededDaysEmbed(succeededDaysTop, previousMonthStart),
+            )
+
             discordHookApi.sendMessage(DiscordHookApi.Request(embeds = embeds))
         } catch (e: Exception) {
             logger().error(
-                "월간 랭킹 디스코드 알림 발송 실패: month={}",
+                "월간 랭킹 발송 실패: month={}",
                 previousMonthStart.month,
                 e,
             )

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/MonthlyRankingServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/MonthlyRankingServiceTest.kt
@@ -178,6 +178,18 @@ class MonthlyRankingServiceTest : FunSpec({
         }
     }
 
+    test("Repository 호출이 예외를 던져도 서비스는 예외를 흡수한다") {
+        every {
+            userStatRepository.findRankingByDateRange(any(), any(), any(), any())
+        } throws RuntimeException("mongo aggregation failed")
+
+        shouldNotThrow<Throwable> {
+            service.sendPreviousMonthRanking()
+        }
+
+        verify(exactly = 0) { discordHookApi.sendMessage(any()) }
+    }
+
     test("두 카테고리에 대해 직전 달 1일~말일을 조회한다") {
         val startSlot = slot<java.time.LocalDate>()
         val endSlot = slot<java.time.LocalDate>()


### PR DESCRIPTION
## 🔎 작업 내용

PR #283 (매월 월간 랭킹 자동 발송)의 CodeRabbit Nitpick 반영.

### Before
```kotlin
val caloriesTop = userStatRepository.findRankingByDateRange(...)  // 예외 시 외부 전파
val succeededDaysTop = userStatRepository.findRankingByDateRange(...)
val embeds = listOf(...)
try {
    discordHookApi.sendMessage(...)  // 이 호출만 흡수
} catch (e: Exception) { ... }
```

### After
```kotlin
try {
    val caloriesTop = userStatRepository.findRankingByDateRange(...)
    val succeededDaysTop = userStatRepository.findRankingByDateRange(...)
    val embeds = listOf(...)
    discordHookApi.sendMessage(...)
} catch (e: Exception) {
    logger().error("월간 랭킹 발송 실패: month={}", previousMonthStart.month, e)
}
```

`previousMonthStart` 계산은 try 밖에 두어 catch 절에서 month 정보 사용 가능. fire-and-forget 정책 유지.

### 변경
- `MonthlyRankingService.sendPreviousMonthRanking()` 메서드 전체로 try/catch 확장
- 단위 테스트 1건 추가: "Repository 호출이 예외를 던져도 서비스는 예외를 흡수한다"

## 영향
- 운영 진단성 향상 — MongoDB 집계 실패 시도 어느 달인지 ERROR 로그에 남음
- 비즈니스 동작 영향 없음 (이미 fire-and-forget 정책)

close #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 월간 랭킹 조회 및 발송 과정의 오류 처리가 개선되었습니다. 이제 데이터 조회부터 메시지 발송까지 전체 프로세스에서 발생할 수 있는 오류가 통일된 방식으로 처리되어 서비스 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->