### PR TITLE
feat: 펫 카탈로그 API + X-Pet-Catalog-Version 헤더 (Phase 1)

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/PetCatalogService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/PetCatalogService.kt
@@ -1,0 +1,43 @@
+package notbe.tmtm.ddanddanserver.application.service
+
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalog
+import notbe.tmtm.ddanddanserver.infrastructure.database.entity.toDomain
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.PetCatalogRepository
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+
+@Service
+class PetCatalogService(
+    private val repository: PetCatalogRepository,
+) {
+    private val versionCache = AtomicReference<CachedVersion?>()
+
+    fun getActiveCatalog(): PetCatalog {
+        val entities = repository.findAllByIsActiveTrueOrderByDisplayOrderAsc()
+        return entities.toDomain()
+    }
+
+    fun currentVersion(): Instant {
+        val now = Instant.now()
+        val cached = versionCache.get()
+        if (cached != null && Duration.between(cached.cachedAt, now) < CACHE_TTL) {
+            return cached.version
+        }
+        val fresh =
+            repository.findAll().maxOfOrNull { it.updatedAt }
+                ?: Instant.EPOCH
+        versionCache.set(CachedVersion(version = fresh, cachedAt = now))
+        return fresh
+    }
+
+    private data class CachedVersion(
+        val version: Instant,
+        val cachedAt: Instant,
+    )
+
+    companion object {
+        private val CACHE_TTL: Duration = Duration.ofSeconds(60)
+    }
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/PetCatalogService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/PetCatalogService.kt
@@ -1,7 +1,7 @@
 package notbe.tmtm.ddanddanserver.application.service
 
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalog
-import notbe.tmtm.ddanddanserver.infrastructure.database.entity.toDomain
+import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.PetCatalogRepository
 import org.springframework.stereotype.Service
 import java.time.Duration
@@ -15,8 +15,11 @@ class PetCatalogService(
     private val versionCache = AtomicReference<CachedVersion?>()
 
     fun getActiveCatalog(): PetCatalog {
-        val entities = repository.findAllByIsActiveTrueOrderByDisplayOrderAsc()
-        return entities.toDomain()
+        val entities: List<PetCatalogEntity> = repository.findAllByIsActiveTrueOrderByDisplayOrderAsc()
+        return PetCatalog(
+            version = currentVersion(),
+            pets = entities.map { it.toDomain() },
+        )
     }
 
     fun currentVersion(): Instant {
@@ -28,7 +31,11 @@ class PetCatalogService(
         val fresh =
             repository.findAll().maxOfOrNull { it.updatedAt }
                 ?: Instant.EPOCH
-        versionCache.set(CachedVersion(version = fresh, cachedAt = now))
+        // CAS — TTL 만료 직후 다수 스레드가 동시에 fresh를 쓰는 race를 줄여 한 번만 갱신
+        if (!versionCache.compareAndSet(cached, CachedVersion(version = fresh, cachedAt = now))) {
+            // 다른 스레드가 먼저 갱신 — 그 결과를 사용
+            return versionCache.get()?.version ?: fresh
+        }
         return fresh
     }
 

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/petcatalog/PetCatalog.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/petcatalog/PetCatalog.kt
@@ -1,0 +1,22 @@
+package notbe.tmtm.ddanddanserver.domain.model.petcatalog
+
+import java.time.Instant
+
+data class PetCatalog(
+    val version: Instant,
+    val pets: List<PetCatalogItem>,
+)
+
+data class PetCatalogItem(
+    val key: String,
+    val name: String,
+    val isActive: Boolean,
+    val displayOrder: Int,
+    val levels: Map<Int, PetCatalogLevel>,
+)
+
+data class PetCatalogLevel(
+    val imageUrl: String,
+    val lottieDefaultUrl: String,
+    val lottiePlayEatUrl: String,
+)

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/PetCatalogEntity.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/PetCatalogEntity.kt
@@ -1,0 +1,72 @@
+package notbe.tmtm.ddanddanserver.infrastructure.database.entity
+
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalog
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogItem
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogLevel
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.Instant
+
+@Document("pet_catalog")
+data class PetCatalogEntity(
+    @Id
+    val id: ObjectId = ObjectId(),
+    @Indexed(unique = true)
+    val key: String,
+    val name: String,
+    val isActive: Boolean = true,
+    val displayOrder: Int = 0,
+    val levels: Map<Int, PetCatalogLevelEntity>,
+    val createdAt: Instant = Instant.now(),
+    val updatedAt: Instant = Instant.now(),
+) {
+    fun toDomain(): PetCatalogItem =
+        PetCatalogItem(
+            key = key,
+            name = name,
+            isActive = isActive,
+            displayOrder = displayOrder,
+            levels = levels.mapValues { it.value.toDomain() },
+        )
+
+    companion object {
+        fun fromDomain(item: PetCatalogItem): PetCatalogEntity =
+            PetCatalogEntity(
+                key = item.key,
+                name = item.name,
+                isActive = item.isActive,
+                displayOrder = item.displayOrder,
+                levels = item.levels.mapValues { PetCatalogLevelEntity.fromDomain(it.value) },
+            )
+    }
+}
+
+data class PetCatalogLevelEntity(
+    val imageUrl: String,
+    val lottieDefaultUrl: String,
+    val lottiePlayEatUrl: String,
+) {
+    fun toDomain(): PetCatalogLevel =
+        PetCatalogLevel(
+            imageUrl = imageUrl,
+            lottieDefaultUrl = lottieDefaultUrl,
+            lottiePlayEatUrl = lottiePlayEatUrl,
+        )
+
+    companion object {
+        fun fromDomain(level: PetCatalogLevel): PetCatalogLevelEntity =
+            PetCatalogLevelEntity(
+                imageUrl = level.imageUrl,
+                lottieDefaultUrl = level.lottieDefaultUrl,
+                lottiePlayEatUrl = level.lottiePlayEatUrl,
+            )
+    }
+}
+
+fun List<PetCatalogEntity>.toDomain(): PetCatalog =
+    PetCatalog(
+        version = this.maxOfOrNull { it.updatedAt } ?: Instant.EPOCH,
+        pets = this.map { it.toDomain() },
+    )

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/PetCatalogRepository.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/PetCatalogRepository.kt
@@ -1,0 +1,9 @@
+package notbe.tmtm.ddanddanserver.infrastructure.database.repository
+
+import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogEntity
+import org.bson.types.ObjectId
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface PetCatalogRepository : MongoRepository<PetCatalogEntity, ObjectId> {
+    fun findAllByIsActiveTrueOrderByDisplayOrderAsc(): List<PetCatalogEntity>
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/seed/PetCatalogSeeder.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/seed/PetCatalogSeeder.kt
@@ -5,6 +5,7 @@ import notbe.tmtm.ddanddanserver.common.util.logger
 import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogLevelEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.PetCatalogRepository
+import org.springframework.dao.DuplicateKeyException
 import org.springframework.stereotype.Component
 import java.time.Instant
 
@@ -28,8 +29,13 @@ class PetCatalogSeeder(
                     updatedAt = now,
                 )
             }
-        repository.saveAll(entities)
-        logger().info("PetCatalog seeded with {} default pets", entities.size)
+        try {
+            repository.saveAll(entities)
+            logger().info("PetCatalog seeded with {} default pets", entities.size)
+        } catch (e: DuplicateKeyException) {
+            // 다중 인스턴스 동시 startup 시 다른 인스턴스가 먼저 seed한 경우
+            logger().info("PetCatalog seed skipped: 이미 다른 인스턴스가 시드 데이터를 등록했습니다", e)
+        }
     }
 
     private fun buildLevels(species: String): Map<Int, PetCatalogLevelEntity> =

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/seed/PetCatalogSeeder.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/seed/PetCatalogSeeder.kt
@@ -1,0 +1,62 @@
+package notbe.tmtm.ddanddanserver.infrastructure.database.seed
+
+import jakarta.annotation.PostConstruct
+import notbe.tmtm.ddanddanserver.common.util.logger
+import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogEntity
+import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogLevelEntity
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.PetCatalogRepository
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+@Component
+class PetCatalogSeeder(
+    private val repository: PetCatalogRepository,
+) {
+    @PostConstruct
+    fun seed() {
+        if (repository.count() > 0L) return
+        val now = Instant.now()
+        val entities =
+            DEFAULT_PETS.mapIndexed { index, pet ->
+                PetCatalogEntity(
+                    key = pet.key,
+                    name = pet.name,
+                    isActive = true,
+                    displayOrder = index,
+                    levels = buildLevels(pet.species),
+                    createdAt = now,
+                    updatedAt = now,
+                )
+            }
+        repository.saveAll(entities)
+        logger().info("PetCatalog seeded with {} default pets", entities.size)
+    }
+
+    private fun buildLevels(species: String): Map<Int, PetCatalogLevelEntity> =
+        (1..MAX_LEVEL).associateWith { level ->
+            PetCatalogLevelEntity(
+                imageUrl = "$CDN_BASE/${species}_level$level.png",
+                lottieDefaultUrl = "$CDN_BASE/${species}_level${level}_default.json",
+                lottiePlayEatUrl = "$CDN_BASE/${species}_level${level}_play_eat.json",
+            )
+        }
+
+    private data class PetSeed(
+        val key: String,
+        val name: String,
+        val species: String,
+    )
+
+    companion object {
+        private const val CDN_BASE = "https://ddan-ddan-cdn.ddmz.org"
+        private const val MAX_LEVEL = 5
+        private val DEFAULT_PETS =
+            listOf(
+                PetSeed(key = "CAT", name = "고양이", species = "cat"),
+                PetSeed(key = "HAMSTER", name = "햄스터", species = "hamster"),
+                PetSeed(key = "PENGUIN", name = "펭귄", species = "penguin"),
+                PetSeed(key = "DOG", name = "강아지", species = "dog"),
+                PetSeed(key = "MOLE", name = "두더지", species = "mole"),
+            )
+    }
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/PetCatalogController.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/PetCatalogController.kt
@@ -1,0 +1,22 @@
+package notbe.tmtm.ddanddanserver.presentation.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import notbe.tmtm.ddanddanserver.application.service.PetCatalogService
+import notbe.tmtm.ddanddanserver.presentation.dto.response.PetCatalogResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/pets")
+@Tag(name = "펫 카탈로그", description = "사용 가능한 펫 메타데이터 + 미디어 URL 제공")
+class PetCatalogController(
+    private val petCatalogService: PetCatalogService,
+) {
+    @Operation(summary = "펫 카탈로그 조회", description = "활성 펫 목록과 카탈로그 버전 반환. 클라이언트는 응답의 version 또는 X-Pet-Catalog-Version 헤더로 stale 캐시 감지 가능.")
+    @ApiResponse(responseCode = "200", description = "성공")
+    @GetMapping("/catalog")
+    fun getCatalog(): PetCatalogResponse = PetCatalogResponse.from(petCatalogService.getActiveCatalog())
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/PetCatalogResponse.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/PetCatalogResponse.kt
@@ -1,0 +1,52 @@
+package notbe.tmtm.ddanddanserver.presentation.dto.response
+
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalog
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogItem
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogLevel
+
+data class PetCatalogResponse(
+    val version: String,
+    val pets: List<PetCatalogItemResponse>,
+) {
+    companion object {
+        fun from(catalog: PetCatalog): PetCatalogResponse =
+            PetCatalogResponse(
+                version = catalog.version.toString(),
+                pets = catalog.pets.map { PetCatalogItemResponse.from(it) },
+            )
+    }
+}
+
+data class PetCatalogItemResponse(
+    val key: String,
+    val name: String,
+    val isActive: Boolean,
+    val displayOrder: Int,
+    val levels: Map<Int, PetCatalogLevelResponse>,
+) {
+    companion object {
+        fun from(item: PetCatalogItem): PetCatalogItemResponse =
+            PetCatalogItemResponse(
+                key = item.key,
+                name = item.name,
+                isActive = item.isActive,
+                displayOrder = item.displayOrder,
+                levels = item.levels.mapValues { PetCatalogLevelResponse.from(it.value) },
+            )
+    }
+}
+
+data class PetCatalogLevelResponse(
+    val imageUrl: String,
+    val lottieDefaultUrl: String,
+    val lottiePlayEatUrl: String,
+) {
+    companion object {
+        fun from(level: PetCatalogLevel): PetCatalogLevelResponse =
+            PetCatalogLevelResponse(
+                imageUrl = level.imageUrl,
+                lottieDefaultUrl = level.lottieDefaultUrl,
+                lottiePlayEatUrl = level.lottiePlayEatUrl,
+            )
+    }
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/filter/PetCatalogVersionFilter.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/filter/PetCatalogVersionFilter.kt
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import notbe.tmtm.ddanddanserver.application.service.PetCatalogService
+import notbe.tmtm.ddanddanserver.common.util.logger
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
@@ -16,7 +17,12 @@ class PetCatalogVersionFilter(
         response: HttpServletResponse,
         filterChain: FilterChain,
     ) {
-        response.setHeader(HEADER_NAME, petCatalogService.currentVersion().toString())
+        // 헤더는 부가 정보이므로 catalog 조회 실패가 본 요청 처리를 차단하지 않도록 흡수
+        try {
+            response.setHeader(HEADER_NAME, petCatalogService.currentVersion().toString())
+        } catch (e: Exception) {
+            logger().warn("X-Pet-Catalog-Version 헤더 설정 실패, 요청 처리는 계속 진행", e)
+        }
         filterChain.doFilter(request, response)
     }
 

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/filter/PetCatalogVersionFilter.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/filter/PetCatalogVersionFilter.kt
@@ -1,0 +1,26 @@
+package notbe.tmtm.ddanddanserver.presentation.filter
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import notbe.tmtm.ddanddanserver.application.service.PetCatalogService
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class PetCatalogVersionFilter(
+    private val petCatalogService: PetCatalogService,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        response.setHeader(HEADER_NAME, petCatalogService.currentVersion().toString())
+        filterChain.doFilter(request, response)
+    }
+
+    companion object {
+        const val HEADER_NAME = "X-Pet-Catalog-Version"
+    }
+}

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/PetCatalogServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/PetCatalogServiceTest.kt
@@ -1,0 +1,100 @@
+package notbe.tmtm.ddanddanserver.application.service
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogEntity
+import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogLevelEntity
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.PetCatalogRepository
+import java.time.Instant
+
+class PetCatalogServiceTest : FunSpec({
+    lateinit var repository: PetCatalogRepository
+    lateinit var service: PetCatalogService
+
+    fun entity(
+        key: String,
+        order: Int,
+        isActive: Boolean = true,
+        updatedAt: Instant = Instant.parse("2026-05-04T00:00:00Z"),
+    ): PetCatalogEntity =
+        PetCatalogEntity(
+            key = key,
+            name = key,
+            isActive = isActive,
+            displayOrder = order,
+            levels =
+                (1..5).associateWith {
+                    PetCatalogLevelEntity(
+                        imageUrl = "https://cdn/$key/$it.png",
+                        lottieDefaultUrl = "https://cdn/$key/${it}_default.json",
+                        lottiePlayEatUrl = "https://cdn/$key/${it}_play_eat.json",
+                    )
+                },
+            createdAt = updatedAt,
+            updatedAt = updatedAt,
+        )
+
+    beforeEach {
+        repository = mockk()
+        service = PetCatalogService(repository)
+    }
+
+    test("getActiveCatalog는 displayOrder 순서대로 활성 펫만 반환한다") {
+        val entities =
+            listOf(
+                entity("CAT", order = 0),
+                entity("DOG", order = 1),
+            )
+        every { repository.findAllByIsActiveTrueOrderByDisplayOrderAsc() } returns entities
+
+        val result = service.getActiveCatalog()
+
+        result.pets.map { it.key } shouldBe listOf("CAT", "DOG")
+    }
+
+    test("getActiveCatalog의 version은 모든 펫 중 max(updatedAt)이다") {
+        val older = Instant.parse("2026-05-01T00:00:00Z")
+        val newer = Instant.parse("2026-05-04T12:00:00Z")
+        every { repository.findAllByIsActiveTrueOrderByDisplayOrderAsc() } returns
+            listOf(
+                entity("CAT", order = 0, updatedAt = older),
+                entity("DOG", order = 1, updatedAt = newer),
+            )
+
+        service.getActiveCatalog().version shouldBe newer
+    }
+
+    test("데이터가 비어있으면 catalog version은 Instant EPOCH이다") {
+        every { repository.findAllByIsActiveTrueOrderByDisplayOrderAsc() } returns emptyList()
+
+        service.getActiveCatalog().version shouldBe Instant.EPOCH
+    }
+
+    test("currentVersion은 max(updatedAt)을 반환한다") {
+        val newest = Instant.parse("2026-05-04T18:00:00Z")
+        every { repository.findAll() } returns
+            listOf(
+                entity("CAT", order = 0, updatedAt = Instant.parse("2026-05-01T00:00:00Z")),
+                entity("DOG", order = 1, updatedAt = newest),
+            )
+
+        service.currentVersion() shouldBe newest
+    }
+
+    test("currentVersion은 60초 TTL 캐시로 동일 시점 반복 호출 시 repository를 한 번만 조회한다") {
+        every { repository.findAll() } returns listOf(entity("CAT", order = 0))
+
+        repeat(5) { service.currentVersion() }
+
+        verify(exactly = 1) { repository.findAll() }
+    }
+
+    test("데이터가 없으면 currentVersion은 Instant EPOCH를 반환한다") {
+        every { repository.findAll() } returns emptyList()
+
+        service.currentVersion() shouldBe Instant.EPOCH
+    }
+})

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/PetCatalogServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/PetCatalogServiceTest.kt
@@ -49,26 +49,34 @@ class PetCatalogServiceTest : FunSpec({
                 entity("DOG", order = 1),
             )
         every { repository.findAllByIsActiveTrueOrderByDisplayOrderAsc() } returns entities
+        every { repository.findAll() } returns entities
 
         val result = service.getActiveCatalog()
 
         result.pets.map { it.key } shouldBe listOf("CAT", "DOG")
     }
 
-    test("getActiveCatalog의 version은 모든 펫 중 max(updatedAt)이다") {
-        val older = Instant.parse("2026-05-01T00:00:00Z")
-        val newer = Instant.parse("2026-05-04T12:00:00Z")
+    test("getActiveCatalog의 version은 currentVersion과 동일하다 (헤더와 응답 body 버전 일치 보장)") {
+        val activeOldUpdatedAt = Instant.parse("2026-05-01T00:00:00Z")
+        val inactiveNewUpdatedAt = Instant.parse("2026-05-04T12:00:00Z")
         every { repository.findAllByIsActiveTrueOrderByDisplayOrderAsc() } returns
+            listOf(entity("CAT", order = 0, updatedAt = activeOldUpdatedAt))
+        every { repository.findAll() } returns
             listOf(
-                entity("CAT", order = 0, updatedAt = older),
-                entity("DOG", order = 1, updatedAt = newer),
+                entity("CAT", order = 0, updatedAt = activeOldUpdatedAt),
+                entity("HIDDEN", order = 99, isActive = false, updatedAt = inactiveNewUpdatedAt),
             )
 
-        service.getActiveCatalog().version shouldBe newer
+        val catalog = service.getActiveCatalog()
+
+        // 비활성 펫이 가장 최신 updatedAt이라도 헤더(currentVersion)와 응답 body version이 일치
+        catalog.version shouldBe service.currentVersion()
+        catalog.version shouldBe inactiveNewUpdatedAt
     }
 
     test("데이터가 비어있으면 catalog version은 Instant EPOCH이다") {
         every { repository.findAllByIsActiveTrueOrderByDisplayOrderAsc() } returns emptyList()
+        every { repository.findAll() } returns emptyList()
 
         service.getActiveCatalog().version shouldBe Instant.EPOCH
     }

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/PetCatalogControllerIntegrationTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/PetCatalogControllerIntegrationTest.kt
@@ -1,0 +1,88 @@
+package notbe.tmtm.ddanddanserver.presentation.controller
+
+import io.mockk.every
+import io.mockk.mockk
+import notbe.tmtm.ddanddanserver.application.service.PetCatalogService
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalog
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogItem
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogLevel
+import notbe.tmtm.ddanddanserver.presentation.filter.PetCatalogVersionFilter
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.Instant
+
+/**
+ * 통합 테스트 — Spring 컨텍스트에서 Controller + Filter wiring을 검증.
+ *
+ * Filter가 모든 응답에 X-Pet-Catalog-Version 헤더를 글로벌하게 추가하는지,
+ * 그리고 Controller JSON 응답이 정상인지 동시에 확인.
+ */
+@WebMvcTest(
+    controllers = [PetCatalogController::class],
+    excludeAutoConfiguration = [SecurityAutoConfiguration::class],
+)
+@Import(PetCatalogControllerIntegrationTest.TestConfig::class)
+class PetCatalogControllerIntegrationTest {
+    @TestConfiguration
+    class TestConfig {
+        @Bean
+        fun petCatalogService(): PetCatalogService = mockk(relaxed = true)
+
+        @Bean
+        fun petCatalogVersionFilter(petCatalogService: PetCatalogService): PetCatalogVersionFilter =
+            PetCatalogVersionFilter(petCatalogService)
+    }
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var petCatalogService: PetCatalogService
+
+    @Test
+    fun `GET catalog는 활성 펫 목록과 version을 반환하고 응답 헤더에 X-Pet-Catalog-Version을 포함한다`() {
+        val now = Instant.parse("2026-05-04T12:00:00Z")
+        every { petCatalogService.getActiveCatalog() } returns
+            PetCatalog(
+                version = now,
+                pets =
+                    listOf(
+                        PetCatalogItem(
+                            key = "CAT",
+                            name = "고양이",
+                            isActive = true,
+                            displayOrder = 0,
+                            levels =
+                                mapOf(
+                                    1 to
+                                        PetCatalogLevel(
+                                            imageUrl = "https://cdn/cat_level1.png",
+                                            lottieDefaultUrl = "https://cdn/cat_level1_default.json",
+                                            lottiePlayEatUrl = "https://cdn/cat_level1_play_eat.json",
+                                        ),
+                                ),
+                        ),
+                    ),
+            )
+        every { petCatalogService.currentVersion() } returns now
+
+        mockMvc
+            .perform(get("/v1/pets/catalog"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.version").value("2026-05-04T12:00:00Z"))
+            .andExpect(jsonPath("$.pets[0].key").value("CAT"))
+            .andExpect(jsonPath("$.pets[0].name").value("고양이"))
+            .andExpect(jsonPath("$.pets[0].levels.1.imageUrl").value("https://cdn/cat_level1.png"))
+            .andExpect(header().string("X-Pet-Catalog-Version", "2026-05-04T12:00:00Z"))
+    }
+}

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/filter/PetCatalogVersionFilterTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/filter/PetCatalogVersionFilterTest.kt
@@ -1,0 +1,36 @@
+package notbe.tmtm.ddanddanserver.presentation.filter
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import notbe.tmtm.ddanddanserver.application.service.PetCatalogService
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import java.time.Instant
+
+class PetCatalogVersionFilterTest : FunSpec({
+    test("응답에 X-Pet-Catalog-Version 헤더를 추가한다") {
+        val service = mockk<PetCatalogService>()
+        val filter = PetCatalogVersionFilter(service)
+        every { service.currentVersion() } returns Instant.parse("2026-05-04T12:34:56Z")
+
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        filter.doFilter(request, response, MockFilterChain())
+
+        response.getHeader("X-Pet-Catalog-Version") shouldBe "2026-05-04T12:34:56Z"
+    }
+
+    test("catalog가 비어있을 때도 EPOCH 값을 헤더로 추가한다 (헤더 항상 존재)") {
+        val service = mockk<PetCatalogService>()
+        val filter = PetCatalogVersionFilter(service)
+        every { service.currentVersion() } returns Instant.EPOCH
+
+        val response = MockHttpServletResponse()
+        filter.doFilter(MockHttpServletRequest(), response, MockFilterChain())
+
+        response.getHeader("X-Pet-Catalog-Version") shouldBe Instant.EPOCH.toString()
+    }
+})

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/filter/PetCatalogVersionFilterTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/filter/PetCatalogVersionFilterTest.kt
@@ -33,4 +33,23 @@ class PetCatalogVersionFilterTest : FunSpec({
 
         response.getHeader("X-Pet-Catalog-Version") shouldBe Instant.EPOCH.toString()
     }
+
+    test("currentVersion 호출이 예외를 던져도 filterChain은 호출되어 본 요청 처리는 계속된다") {
+        val service = mockk<PetCatalogService>()
+        val filter = PetCatalogVersionFilter(service)
+        every { service.currentVersion() } throws RuntimeException("DB unreachable")
+
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        io.kotest.assertions.throwables.shouldNotThrow<Throwable> {
+            filter.doFilter(request, response, chain)
+        }
+
+        // 헤더는 누락되지만 chain은 정상 진행
+        response.getHeader("X-Pet-Catalog-Version") shouldBe null
+        chain.request shouldBe request
+        chain.response shouldBe response
+    }
 })


### PR DESCRIPTION
## 🔎 작업 내용

기존 클라이언트 펫 미디어(이미지·Lottie)를 서버 동적 카탈로그로 분리하기 위한 첫 단계 (5단계 로드맵 중 Phase 1). **클라 배포 없이 신규 펫 추가 가능 구조의 토대.**

### 변경
- **`pet_catalog` 컬렉션** — key/name/isActive/displayOrder/levels[1..5]/createdAt/updatedAt
- **`GET /v1/pets/catalog`** — 활성 펫 목록 + version
- **글로벌 `PetCatalogVersionFilter`** — 모든 응답에 `X-Pet-Catalog-Version` 헤더 추가 (`max(updatedAt)` ISO 8601)
- **60초 TTL in-memory 버전 캐시** — 매 요청 DB 조회 부담 차단
- **`PetCatalogSeeder`** — `count == 0`일 때만 5종 자동 등록 (고양이/햄스터/펭귄/강아지/두더지). URL은 `https://ddan-ddan-cdn.ddmz.org/{species}_level{N}.{ext}` placeholder

### 응답 예시
```json
{
  "version": "2026-05-04T12:34:56Z",
  "pets": [
    {
      "key": "CAT",
      "name": "고양이",
      "isActive": true,
      "displayOrder": 0,
      "levels": {
        "1": {
          "imageUrl": "https://ddan-ddan-cdn.ddmz.org/cat_level1.png",
          "lottieDefaultUrl": "https://ddan-ddan-cdn.ddmz.org/cat_level1_default.json",
          "lottiePlayEatUrl": "https://ddan-ddan-cdn.ddmz.org/cat_level1_play_eat.json"
        },
        ...
      }
    },
    ...
  ]
}
```
응답 헤더: `X-Pet-Catalog-Version: 2026-05-04T12:34:56Z`

### 변경 파일 (11개)
**도메인** — `domain/model/petcatalog/PetCatalog.kt`
**인프라** — `database/entity/PetCatalogEntity.kt`, `database/repository/PetCatalogRepository.kt`, `database/seed/PetCatalogSeeder.kt`
**응용** — `service/PetCatalogService.kt`
**프레젠테이션** — `controller/PetCatalogController.kt`, `dto/response/PetCatalogResponse.kt`, `filter/PetCatalogVersionFilter.kt`
**테스트** — Service 6 + Filter 2 + Controller 통합 1

## 안 하는 것 (사용자 결정)
- admin endpoint — mongo 직접 INSERT/UPDATE로 운영
- 기존 `PetType` enum / `Pet.type` 필드 변경 — Phase 5에서 별도 PR

## 다음 단계
- **Phase 2**: R2에 실제 미디어 파일 업로드 + catalog URL 갱신 (코드 변경 없음, 운영 작업)
- **Phase 3**: 클라 catalog 도입 (iOS/Android 별도 PR)
- **Phase 4**: 첫 신규 펫 출시
- **Phase 5 (선택)**: 번들 fallback 정리

close #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 펫 카탈로그 조회 API 엔드포인트 추가 (`GET /v1/pets/catalog`)
- 카탈로그 버전 추적 기능 구현
- 모든 HTTP 응답에 `X-Pet-Catalog-Version` 헤더로 현재 카탈로그 버전 정보 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->