### PR TITLE
chore: 펫 카탈로그 URL을 species 폴더 구조로 통일

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/seed/PetCatalogSeeder.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/seed/PetCatalogSeeder.kt
@@ -41,9 +41,9 @@ class PetCatalogSeeder(
     private fun buildLevels(species: String): Map<Int, PetCatalogLevelEntity> =
         (1..MAX_LEVEL).associateWith { level ->
             PetCatalogLevelEntity(
-                imageUrl = "$CDN_BASE/${species}_level$level.png",
-                lottieDefaultUrl = "$CDN_BASE/${species}_level${level}_default.json",
-                lottiePlayEatUrl = "$CDN_BASE/${species}_level${level}_play_eat.json",
+                imageUrl = "$CDN_BASE/$species/level$level.png",
+                lottieDefaultUrl = "$CDN_BASE/$species/level${level}_default.json",
+                lottiePlayEatUrl = "$CDN_BASE/$species/level${level}_play_eat.json",
             )
         }
 


### PR DESCRIPTION
## 🔎 작업 내용

PR #287 catalog seeder의 URL 패턴이 평면이라 R2 대시보드에서 펫별 분리가 어렵고 파일이 섞여서 관리 부담. species 폴더 구조로 통일.

### Before
```
https://ddan-ddan-cdn.ddmz.org/cat_level1.png
https://ddan-ddan-cdn.ddmz.org/cat_level1_default.json
https://ddan-ddan-cdn.ddmz.org/cat_level1_play_eat.json
```

### After
```
https://ddan-ddan-cdn.ddmz.org/cat/level1.png
https://ddan-ddan-cdn.ddmz.org/cat/level1_default.json
https://ddan-ddan-cdn.ddmz.org/cat/level1_play_eat.json
```

폴더가 species 역할을 하므로 파일명에서 species 접두어 제거.

## 변경
- `PetCatalogSeeder.buildLevels()` URL 빌더 변경 (3줄)

## 별도 작업 (이번 PR 외)

머지 후 dev/prod 운영 디렉토리에서 mongo CLI로 일회성:
```
db.pet_catalog.deleteMany({})
```
컨테이너 재시작 시 PetCatalogSeeder가 새 URL 패턴으로 자동 재seed.

## 영향
- catalog API 응답 URL 변경 (클라가 아직 catalog 사용 안 함 — Phase 1 끝, Phase 2/3 진행 전이라 사용자 영향 0)
- Phase 2(R2 업로드) 시 폴더 구조로 업로드 — `cat/`, `dog/`, `hamster/`, `mole/`, `penguin/` 5개 폴더에 각 15개 파일

close #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 펫 미디어 리소스의 CDN 경로 형식을 최적화했습니다. 이미지 및 애니메이션 파일의 URL 구조가 개선되어 더 나은 리소스 관리를 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->