### PR TITLE
feat: 어드민 유저 lastLoginAt 노출 + 일별 칼로리 기록 조회

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/UserAdminService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/UserAdminService.kt
@@ -1,16 +1,20 @@
 package notbe.tmtm.ddanddanserver.application.service
 
+import notbe.tmtm.ddanddanserver.domain.model.user.DailyInfo
 import notbe.tmtm.ddanddanserver.domain.model.user.User
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.DailyInfoRepository
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserRepository
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.findByIdOrThrow
 import org.bson.types.ObjectId
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 @Service
 class UserAdminService(
     private val userRepository: UserRepository,
+    private val dailyInfoRepository: DailyInfoRepository,
 ) {
     fun searchUsers(
         keyword: String?,
@@ -28,4 +32,14 @@ class UserAdminService(
     }
 
     fun getUser(userId: ObjectId): User = userRepository.findByIdOrThrow(userId)
+
+    fun getDailyCalories(
+        userId: ObjectId,
+        from: LocalDate,
+        to: LocalDate,
+    ): List<DailyInfo> {
+        // 유저 존재 확인 — 없으면 UserNotFoundException
+        userRepository.findByIdOrThrow(userId)
+        return dailyInfoRepository.findAllByUserIdAndDateBetweenOrderByDateDesc(userId, from, to)
+    }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/DailyInfoRepository.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/DailyInfoRepository.kt
@@ -16,5 +16,11 @@ interface DailyInfoRepository : MongoRepository<DailyInfo, ObjectId> {
         purposeAchieved: Boolean,
     ): List<DailyInfo>
 
+    fun findAllByUserIdAndDateBetweenOrderByDateDesc(
+        userId: ObjectId,
+        from: LocalDate,
+        to: LocalDate,
+    ): List<DailyInfo>
+
     fun deleteAllByUserId(userId: ObjectId)
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/UserAdminController.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/UserAdminController.kt
@@ -1,6 +1,8 @@
 package notbe.tmtm.ddanddanserver.presentation.controller.admin
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
@@ -51,20 +53,33 @@ class UserAdminController(
 
     @Operation(
         summary = "유저 일별 칼로리 기록 조회",
-        description = "기간 미지정 시 최근 30일. from/to는 YYYY-MM-DD 형식.",
+        description = "기간 미지정 시 최근 30일. from/to는 YYYY-MM-DD 형식. 최대 조회 기간 366일.",
     )
+    @ApiResponse(responseCode = "200", description = "성공")
+    @ApiResponse(responseCode = "400", description = "기간 파라미터 오류 (from > to 또는 366일 초과)")
+    @ApiResponse(responseCode = "404", description = "유저 미존재")
     @GetMapping("/{id}/daily-calories")
     fun dailyCalories(
-        @PathVariable id: String,
+        @Parameter(description = "유저 ObjectId hex string", required = true)
+        @PathVariable
+        id: String,
+        @Parameter(description = "조회 시작일 YYYY-MM-DD (미지정 시 to-29일)")
         @RequestParam(required = false)
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         from: LocalDate?,
+        @Parameter(description = "조회 종료일 YYYY-MM-DD (미지정 시 오늘)")
         @RequestParam(required = false)
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         to: LocalDate?,
     ): DailyCaloriesAdminListResponse {
         val effectiveTo = to ?: LocalDate.now()
         val effectiveFrom = from ?: effectiveTo.minusDays(DEFAULT_RANGE_DAYS)
+
+        require(!effectiveFrom.isAfter(effectiveTo)) { "from은 to보다 이전이어야 합니다." }
+        require(java.time.temporal.ChronoUnit.DAYS.between(effectiveFrom, effectiveTo) <= MAX_RANGE_DAYS) {
+            "조회 기간은 최대 ${MAX_RANGE_DAYS + 1}일 입니다."
+        }
+
         val records =
             userAdminService.getDailyCalories(
                 userId = ObjectId(id),
@@ -81,5 +96,6 @@ class UserAdminController(
 
     companion object {
         private const val DEFAULT_RANGE_DAYS: Long = 29 // (오늘 포함 30일)
+        private const val MAX_RANGE_DAYS: Long = 365 // 최대 366일 조회 (윤년 포함)
     }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/UserAdminController.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/UserAdminController.kt
@@ -6,15 +6,18 @@ import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import notbe.tmtm.ddanddanserver.application.service.UserAdminService
 import notbe.tmtm.ddanddanserver.application.service.UserAdminSortType
+import notbe.tmtm.ddanddanserver.presentation.dto.admin.DailyCaloriesAdminListResponse
 import notbe.tmtm.ddanddanserver.presentation.dto.admin.UserAdminDetailResponse
 import notbe.tmtm.ddanddanserver.presentation.dto.admin.UserAdminListResponse
 import org.bson.types.ObjectId
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
 
 @RestController
 @RequestMapping("/v1/admin/users")
@@ -45,4 +48,38 @@ class UserAdminController(
     fun detail(
         @PathVariable id: String,
     ): UserAdminDetailResponse = UserAdminDetailResponse.from(userAdminService.getUser(ObjectId(id)))
+
+    @Operation(
+        summary = "유저 일별 칼로리 기록 조회",
+        description = "기간 미지정 시 최근 30일. from/to는 YYYY-MM-DD 형식.",
+    )
+    @GetMapping("/{id}/daily-calories")
+    fun dailyCalories(
+        @PathVariable id: String,
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        from: LocalDate?,
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        to: LocalDate?,
+    ): DailyCaloriesAdminListResponse {
+        val effectiveTo = to ?: LocalDate.now()
+        val effectiveFrom = from ?: effectiveTo.minusDays(DEFAULT_RANGE_DAYS)
+        val records =
+            userAdminService.getDailyCalories(
+                userId = ObjectId(id),
+                from = effectiveFrom,
+                to = effectiveTo,
+            )
+        return DailyCaloriesAdminListResponse.from(
+            userId = id,
+            from = effectiveFrom.toString(),
+            to = effectiveTo.toString(),
+            records = records,
+        )
+    }
+
+    companion object {
+        private const val DEFAULT_RANGE_DAYS: Long = 29 // (오늘 포함 30일)
+    }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/admin/DailyCaloriesAdminDto.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/admin/DailyCaloriesAdminDto.kt
@@ -1,0 +1,45 @@
+package notbe.tmtm.ddanddanserver.presentation.dto.admin
+
+import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
+import notbe.tmtm.ddanddanserver.domain.model.user.DailyInfo
+
+data class DailyCaloriesAdminListResponse(
+    val userId: String,
+    val from: String,
+    val to: String,
+    val records: List<DailyCaloriesAdminItemResponse>,
+) {
+    companion object {
+        fun from(
+            userId: String,
+            from: String,
+            to: String,
+            records: List<DailyInfo>,
+        ): DailyCaloriesAdminListResponse =
+            DailyCaloriesAdminListResponse(
+                userId = userId,
+                from = from,
+                to = to,
+                records = records.map { DailyCaloriesAdminItemResponse.from(it) },
+            )
+    }
+}
+
+data class DailyCaloriesAdminItemResponse(
+    val date: String,
+    val calorie: Int,
+    val purposeAchieved: Boolean,
+    val toyGiven: Boolean,
+    val petType: PetType?,
+) {
+    companion object {
+        fun from(info: DailyInfo): DailyCaloriesAdminItemResponse =
+            DailyCaloriesAdminItemResponse(
+                date = info.date.toString(),
+                calorie = info.calorie,
+                purposeAchieved = info.purposeAchieved,
+                toyGiven = info.toyGiven,
+                petType = info.petType,
+            )
+    }
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/admin/UserAdminDto.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/admin/UserAdminDto.kt
@@ -9,6 +9,7 @@ data class UserAdminSummaryResponse(
     val mainPetId: String?,
     val tickets: Int,
     val purposeCalorie: Int,
+    val lastLoginAt: String,
 ) {
     companion object {
         fun from(user: User): UserAdminSummaryResponse =
@@ -18,6 +19,7 @@ data class UserAdminSummaryResponse(
                 mainPetId = user.mainPetId?.toHexString(),
                 tickets = user.tickets,
                 purposeCalorie = user.purposeCalorie,
+                lastLoginAt = user.lastLoginAt.toString(),
             )
     }
 }

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/UserAdminServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/UserAdminServiceTest.kt
@@ -8,16 +8,21 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import notbe.tmtm.ddanddanserver.domain.exception.UserNotFoundException
+import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
+import notbe.tmtm.ddanddanserver.domain.model.user.DailyInfo
 import notbe.tmtm.ddanddanserver.domain.model.user.DeviceToken
 import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.domain.model.user.UserSetting
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.DailyInfoRepository
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserRepository
 import org.bson.types.ObjectId
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
+import java.time.LocalDate
 
 class UserAdminServiceTest : FunSpec({
     lateinit var repository: UserRepository
+    lateinit var dailyInfoRepository: DailyInfoRepository
     lateinit var service: UserAdminService
 
     fun user(name: String?): User =
@@ -28,9 +33,26 @@ class UserAdminServiceTest : FunSpec({
             setting = UserSetting(),
         )
 
+    fun dailyInfo(
+        userId: ObjectId,
+        date: LocalDate,
+        calorie: Int,
+    ): DailyInfo =
+        DailyInfo(
+            id = ObjectId(),
+            userId = userId,
+            userName = "테스터",
+            petType = PetType.CAT,
+            calorie = calorie,
+            purposeAchieved = calorie >= 100,
+            toyGiven = false,
+            date = date,
+        )
+
     beforeEach {
         repository = mockk()
-        service = UserAdminService(repository)
+        dailyInfoRepository = mockk()
+        service = UserAdminService(repository, dailyInfoRepository)
     }
 
     test("keyword가 null이면 findAll(pageable)을 호출한다") {
@@ -109,6 +131,37 @@ class UserAdminServiceTest : FunSpec({
 
         shouldThrow<UserNotFoundException> {
             service.getUser(id)
+        }
+    }
+
+    test("getDailyCalories는 유저 존재 확인 후 기간 내 daily_calories를 반환한다") {
+        val id = ObjectId()
+        val from = LocalDate.parse("2026-04-01")
+        val to = LocalDate.parse("2026-04-30")
+        every { repository.findById(id) } returns java.util.Optional.of(user("tester"))
+        every {
+            dailyInfoRepository.findAllByUserIdAndDateBetweenOrderByDateDesc(id, from, to)
+        } returns
+            listOf(
+                dailyInfo(id, LocalDate.parse("2026-04-30"), 250),
+                dailyInfo(id, LocalDate.parse("2026-04-29"), 80),
+            )
+
+        val result = service.getDailyCalories(id, from, to)
+
+        result.size shouldBe 2
+        result[0].calorie shouldBe 250
+        result[0].purposeAchieved shouldBe true
+        result[1].calorie shouldBe 80
+        result[1].purposeAchieved shouldBe false
+    }
+
+    test("getDailyCalories는 유저가 존재하지 않으면 UserNotFoundException") {
+        val id = ObjectId()
+        every { repository.findById(id) } returns java.util.Optional.empty()
+
+        shouldThrow<UserNotFoundException> {
+            service.getDailyCalories(id, LocalDate.now().minusDays(7), LocalDate.now())
         }
     }
 })


### PR DESCRIPTION
## 🔎 작업 내용

### 1) UserAdminSummaryResponse에 `lastLoginAt` 추가
어드민 유저 목록에서 마지막 로그인 일자가 노출됩니다. 기존 detail에만 있던 필드를 list 응답에도 포함.

### 2) 유저 일별 칼로리 기록 조회 endpoint 신규
`GET /v1/admin/users/{id}/daily-calories?from=YYYY-MM-DD&to=YYYY-MM-DD`

- daily_calories 컬렉션을 userId + 기간 필터로 조회 (date DESC)
- 응답: `{ userId, from, to, records: [{ date, calorie, purposeAchieved, toyGiven, petType }] }`
- from/to 미지정 시 default 최근 30일 (오늘 포함)
- 유저가 존재하지 않으면 `UserNotFoundException`

## 변경 파일 (6개)

**신규**
- `presentation/dto/admin/DailyCaloriesAdminDto.kt`

**수정**
- `infrastructure/database/repository/DailyInfoRepository.kt` — `findAllByUserIdAndDateBetweenOrderByDateDesc` 메서드 추가
- `application/service/UserAdminService.kt` — `DailyInfoRepository` 주입 + `getDailyCalories` 메서드
- `presentation/controller/admin/UserAdminController.kt` — `GET /{id}/daily-calories` endpoint
- `presentation/dto/admin/UserAdminDto.kt` — `UserAdminSummaryResponse.lastLoginAt`
- 단위 테스트 2건 추가 (정상 / 유저 없음)

## 검증
- 단위 + 기존 통합 테스트 통과

close #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자별 일일 칼로리 기록 조회 기능 추가 (시작일과 종료일로 필터링 가능)
  * 관리자 사용자 정보 조회 시 마지막 로그인 시간 정보 포함

* **테스트**
  * 일일 칼로리 기록 조회 기능에 대한 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->