### PR TITLE
[feat] 어드민 유저 응답에 mainPetType 노출 (#297)

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/UserAdminService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/UserAdminService.kt
@@ -1,8 +1,10 @@
 package notbe.tmtm.ddanddanserver.application.service
 
+import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
 import notbe.tmtm.ddanddanserver.domain.model.user.DailyInfo
 import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.DailyInfoRepository
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.PetRepository
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserRepository
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.findByIdOrThrow
 import org.bson.types.ObjectId
@@ -15,6 +17,7 @@ import java.time.LocalDate
 class UserAdminService(
     private val userRepository: UserRepository,
     private val dailyInfoRepository: DailyInfoRepository,
+    private val petRepository: PetRepository,
 ) {
     fun searchUsers(
         keyword: String?,
@@ -41,5 +44,21 @@ class UserAdminService(
         // 유저 존재 확인 — 없으면 UserNotFoundException
         userRepository.findByIdOrThrow(userId)
         return dailyInfoRepository.findAllByUserIdAndDateBetweenOrderByDateDesc(userId, from, to)
+    }
+
+    /**
+     * 여러 유저의 mainPet `PetType`을 한 번의 쿼리로 조회한다.
+     * 목록 응답에서 N+1을 피하기 위해 사용. mainPetId가 없거나 펫이 삭제된 유저는 결과 맵에 포함되지 않는다.
+     */
+    fun getMainPetTypes(users: List<User>): Map<ObjectId, PetType> {
+        val mainPetIds = users.mapNotNull { it.mainPetId }
+        if (mainPetIds.isEmpty()) return emptyMap()
+        return petRepository.findAllById(mainPetIds).associate { it.id to it.type }
+    }
+
+    /** 단일 유저의 mainPet `PetType`. mainPetId가 없거나 펫이 삭제된 경우 null. */
+    fun getMainPetType(user: User): PetType? {
+        val petId = user.mainPetId ?: return null
+        return petRepository.findById(petId).orElse(null)?.type
     }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/UserAdminController.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/UserAdminController.kt
@@ -35,21 +35,27 @@ class UserAdminController(
         @RequestParam(defaultValue = "20") @Min(1) @Max(100) size: Int,
         @RequestParam(required = false) keyword: String?,
         @RequestParam(defaultValue = "LATEST_LOGIN") sort: UserAdminSortType,
-    ): UserAdminListResponse =
-        UserAdminListResponse.from(
+    ): UserAdminListResponse {
+        val pageResult =
             userAdminService.searchUsers(
                 keyword = keyword,
                 sortType = sort,
                 page = page,
                 size = size,
-            ),
-        )
+            )
+        val mainPetTypes = userAdminService.getMainPetTypes(pageResult.content)
+        return UserAdminListResponse.from(pageResult, mainPetTypes)
+    }
 
     @Operation(summary = "유저 상세")
     @GetMapping("/{id}")
     fun detail(
         @PathVariable id: String,
-    ): UserAdminDetailResponse = UserAdminDetailResponse.from(userAdminService.getUser(ObjectId(id)))
+    ): UserAdminDetailResponse {
+        val user = userAdminService.getUser(ObjectId(id))
+        val mainPetType = userAdminService.getMainPetType(user)
+        return UserAdminDetailResponse.from(user, mainPetType)
+    }
 
     @Operation(
         summary = "유저 일별 칼로리 기록 조회",

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/admin/UserAdminDto.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/admin/UserAdminDto.kt
@@ -1,22 +1,29 @@
 package notbe.tmtm.ddanddanserver.presentation.dto.admin
 
+import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
 import notbe.tmtm.ddanddanserver.domain.model.user.User
+import org.bson.types.ObjectId
 import org.springframework.data.domain.Page
 
 data class UserAdminSummaryResponse(
     val id: String,
     val name: String?,
     val mainPetId: String?,
+    val mainPetType: PetType?,
     val tickets: Int,
     val purposeCalorie: Int,
     val lastLoginAt: String,
 ) {
     companion object {
-        fun from(user: User): UserAdminSummaryResponse =
+        fun from(
+            user: User,
+            mainPetType: PetType? = null,
+        ): UserAdminSummaryResponse =
             UserAdminSummaryResponse(
                 id = user.id.toHexString(),
                 name = user.name,
                 mainPetId = user.mainPetId?.toHexString(),
+                mainPetType = mainPetType,
                 tickets = user.tickets,
                 purposeCalorie = user.purposeCalorie,
                 lastLoginAt = user.lastLoginAt.toString(),
@@ -28,6 +35,7 @@ data class UserAdminDetailResponse(
     val id: String,
     val name: String?,
     val mainPetId: String?,
+    val mainPetType: PetType?,
     val purposeCalorie: Int,
     val foodQuantity: Int,
     val toyQuantity: Int,
@@ -37,11 +45,15 @@ data class UserAdminDetailResponse(
     val lastLoginAt: String,
 ) {
     companion object {
-        fun from(user: User): UserAdminDetailResponse =
+        fun from(
+            user: User,
+            mainPetType: PetType? = null,
+        ): UserAdminDetailResponse =
             UserAdminDetailResponse(
                 id = user.id.toHexString(),
                 name = user.name,
                 mainPetId = user.mainPetId?.toHexString(),
+                mainPetType = mainPetType,
                 purposeCalorie = user.purposeCalorie,
                 foodQuantity = user.foodQuantity,
                 toyQuantity = user.toyQuantity,
@@ -58,9 +70,18 @@ data class UserAdminListResponse(
     val page: PageMetaResponse,
 ) {
     companion object {
-        fun from(page: Page<User>): UserAdminListResponse =
+        fun from(
+            page: Page<User>,
+            mainPetTypes: Map<ObjectId, PetType> = emptyMap(),
+        ): UserAdminListResponse =
             UserAdminListResponse(
-                users = page.content.map { UserAdminSummaryResponse.from(it) },
+                users =
+                    page.content.map { user ->
+                        UserAdminSummaryResponse.from(
+                            user = user,
+                            mainPetType = user.mainPetId?.let { mainPetTypes[it] },
+                        )
+                    },
                 page = PageMetaResponse.from(page),
             )
     }

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/UserAdminServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/UserAdminServiceTest.kt
@@ -8,29 +8,42 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import notbe.tmtm.ddanddanserver.domain.exception.UserNotFoundException
+import notbe.tmtm.ddanddanserver.domain.model.pet.Pet
 import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
 import notbe.tmtm.ddanddanserver.domain.model.user.DailyInfo
 import notbe.tmtm.ddanddanserver.domain.model.user.DeviceToken
 import notbe.tmtm.ddanddanserver.domain.model.user.User
 import notbe.tmtm.ddanddanserver.domain.model.user.UserSetting
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.DailyInfoRepository
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.PetRepository
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.UserRepository
 import org.bson.types.ObjectId
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import java.time.LocalDate
+import java.util.Optional
 
 class UserAdminServiceTest : FunSpec({
     lateinit var repository: UserRepository
     lateinit var dailyInfoRepository: DailyInfoRepository
+    lateinit var petRepository: PetRepository
     lateinit var service: UserAdminService
 
-    fun user(name: String?): User =
+    fun user(name: String?, mainPetId: ObjectId? = null): User =
         User(
             id = ObjectId(),
             deviceToken = DeviceToken("token"),
             name = name,
+            mainPetId = mainPetId,
             setting = UserSetting(),
+        )
+
+    fun pet(type: PetType): Pet =
+        Pet(
+            id = ObjectId(),
+            type = type,
+            ownerUserId = ObjectId(),
+            exp = 0,
         )
 
     fun dailyInfo(
@@ -52,7 +65,8 @@ class UserAdminServiceTest : FunSpec({
     beforeEach {
         repository = mockk()
         dailyInfoRepository = mockk()
-        service = UserAdminService(repository, dailyInfoRepository)
+        petRepository = mockk()
+        service = UserAdminService(repository, dailyInfoRepository, petRepository)
     }
 
     test("keyword가 null이면 findAll(pageable)을 호출한다") {
@@ -118,7 +132,7 @@ class UserAdminServiceTest : FunSpec({
     test("getUser는 ObjectId로 사용자를 조회한다") {
         val id = ObjectId()
         val expected = user("ddingmin")
-        every { repository.findById(id) } returns java.util.Optional.of(expected)
+        every { repository.findById(id) } returns Optional.of(expected)
 
         val result = service.getUser(id)
 
@@ -127,7 +141,7 @@ class UserAdminServiceTest : FunSpec({
 
     test("getUser가 존재하지 않으면 UserNotFoundException") {
         val id = ObjectId()
-        every { repository.findById(id) } returns java.util.Optional.empty()
+        every { repository.findById(id) } returns Optional.empty()
 
         shouldThrow<UserNotFoundException> {
             service.getUser(id)
@@ -138,7 +152,7 @@ class UserAdminServiceTest : FunSpec({
         val id = ObjectId()
         val from = LocalDate.parse("2026-04-01")
         val to = LocalDate.parse("2026-04-30")
-        every { repository.findById(id) } returns java.util.Optional.of(user("tester"))
+        every { repository.findById(id) } returns Optional.of(user("tester"))
         every {
             dailyInfoRepository.findAllByUserIdAndDateBetweenOrderByDateDesc(id, from, to)
         } returns
@@ -158,10 +172,58 @@ class UserAdminServiceTest : FunSpec({
 
     test("getDailyCalories는 유저가 존재하지 않으면 UserNotFoundException") {
         val id = ObjectId()
-        every { repository.findById(id) } returns java.util.Optional.empty()
+        every { repository.findById(id) } returns Optional.empty()
 
         shouldThrow<UserNotFoundException> {
             service.getDailyCalories(id, LocalDate.now().minusDays(7), LocalDate.now())
         }
+    }
+
+    test("getMainPetTypes는 mainPetId가 있는 유저들만 모아 한 번에 조회한다") {
+        val cat = pet(PetType.CAT)
+        val penguin = pet(PetType.PENGUIN)
+        val u1 = user("a", mainPetId = cat.id)
+        val u2 = user("b", mainPetId = null)
+        val u3 = user("c", mainPetId = penguin.id)
+
+        val ids = slot<Iterable<ObjectId>>()
+        every { petRepository.findAllById(capture(ids)) } returns listOf(cat, penguin)
+
+        val result = service.getMainPetTypes(listOf(u1, u2, u3))
+
+        ids.captured.toList() shouldBe listOf(cat.id, penguin.id)
+        result shouldBe mapOf(cat.id to PetType.CAT, penguin.id to PetType.PENGUIN)
+    }
+
+    test("getMainPetTypes는 모든 유저가 mainPetId 없으면 펫 repository를 호출하지 않는다") {
+        val u = user("noPet", mainPetId = null)
+
+        val result = service.getMainPetTypes(listOf(u))
+
+        result shouldBe emptyMap()
+        verify(exactly = 0) { petRepository.findAllById(any<Iterable<ObjectId>>()) }
+    }
+
+    test("getMainPetType는 user의 mainPetId가 null이면 null을 반환하고 repository를 호출하지 않는다") {
+        val u = user("noPet", mainPetId = null)
+
+        service.getMainPetType(u) shouldBe null
+
+        verify(exactly = 0) { petRepository.findById(any()) }
+    }
+
+    test("getMainPetType는 mainPetId가 있으면 펫의 type을 반환한다") {
+        val hamster = pet(PetType.HAMSTER)
+        val u = user("hasPet", mainPetId = hamster.id)
+        every { petRepository.findById(hamster.id) } returns Optional.of(hamster)
+
+        service.getMainPetType(u) shouldBe PetType.HAMSTER
+    }
+
+    test("getMainPetType는 mainPetId가 있어도 펫이 미존재하면 null") {
+        val u = user("stalePet", mainPetId = ObjectId())
+        every { petRepository.findById(any()) } returns Optional.empty()
+
+        service.getMainPetType(u) shouldBe null
     }
 })


### PR DESCRIPTION
## 작업 내용
- \`UserAdminSummaryResponse\` / \`UserAdminDetailResponse\`에 \`mainPetType: PetType?\` 추가
- \`UserAdminService\`에 \`PetRepository\` 주입
  - \`getMainPetTypes(users)\` — 목록 N+1 방지용 배치 조회 (mainPetId가 있는 유저만 모아 \`findAllById\`)
  - \`getMainPetType(user)\` — 단일용
- \`UserAdminController\` list/detail에서 type 매핑 후 응답
- \`UserAdminListResponse.from(page, mainPetTypes = emptyMap())\` — 기본값으로 기존 호출 호환

## 영향 범위
- \`GET /v1/admin/users\` — 응답 \`users[].mainPetType\` 신규 필드 (PetType enum 또는 null)
- \`GET /v1/admin/users/{id}\` — 응답 \`mainPetType\` 신규 필드
- \`UserAdminService\` 생성자 시그니처 변경 (PetRepository 추가)

## 테스트 / 확인 방법
- [x] \`UserAdminServiceTest\` 단위 테스트 신규 4건 통과
  - getMainPetTypes 정상 (mainPetId 없는 유저 스킵 + 한 번의 findAllById 호출)
  - getMainPetTypes 모두 mainPetId 없으면 repository 미호출
  - getMainPetType null mainPetId면 repository 미호출
  - getMainPetType pet 미존재(stale) 시 null
- [x] compileKotlin / compileTestKotlin 통과

## 관련 이슈
Closes #297

## admin 측 후속
\`ddan-ddan-admin\`은 schema에 optional 필드로 미리 추가되어 머지 시 자동으로 type이 노출됩니다.