### PR TITLE
[feat] 어드민 통계 대시보드 endpoint (#299)

### DIFF
--- a/_workspace/01_issue_analysis.md
+++ b/_workspace/01_issue_analysis.md
@@ -1,0 +1,58 @@
+# 이슈 분석: 신규 가입 디스코드 알림
+
+## 요구사항 요약
+
+OAuth(Kakao/Apple) 로그인 흐름에서 **신규 사용자가 처음 생성되는 시점**에 운영팀의 Discord 관리자 채널로 자동 알림을 보낸다. 발송 주체는 서버이며 사용자 행위로 직접 트리거되지 않는다. Discord 연결은 Webhook URL 방식(Bot Token 아님)을 사용하고, URL은 `application.yaml`에 환경변수로 주입한다. 알림 페이로드 후보는 사용자명, OAuth provider(kakao/apple), 가입 시각, 누적 가입자 수다. 기존 사용자 로그인은 알림 대상이 아니다. Webhook 호출 실패가 가입 흐름을 차단해서는 안 된다.
+
+## 영향 받는 레이어
+
+- [ ] domain
+- [x] application
+- [x] infrastructure
+- [ ] presentation
+- [x] config (application.yaml)
+
+신규 도메인 모델은 필요 없음. 알림은 운영팀용 외부 통보일 뿐 비즈니스 도메인 개념이 아니므로 `infrastructure/api`에 Discord HTTP 클라이언트를, `application/service`(또는 `AuthService` 내부)에서 호출 지점을 둔다. presentation 레이어는 변경 없음 (기존 `/auth` 엔드포인트의 응답 시그니처는 유지).
+
+## 관련 코드
+
+| 파일 | 라인 | 역할 |
+|---|---|---|
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/AuthService.kt` | 24-35 | `login()` — OAuth 로그인 진입점. `authRepository.findByOAuthIdAndType` 결과로 신규/기존 분기. |
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/AuthService.kt` | 50-68 | `loginNewUser()` — **신규 가입 분기**. `userRepository.save(...)`로 User 생성 후 `authRepository.save(...)`로 Auth 생성. 알림 호출은 이 메서드의 마지막(저장 성공 직후, return 직전)에 위치해야 한다. |
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/application/processor/OAuth.kt` | 5-9 | OAuth DTO. `id`, `type: OAuthType`, `nickName` 보유 — 알림 페이로드 소스. |
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/auth/OAuthType.kt` | 3-6 | `KAKAO`, `APPLE` enum. provider 표기에 사용. |
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/user/User.kt` | 76-81 | `User.register()` 팩토리. 신규 User 식별자/이름이 여기서 만들어진다. |
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/api/SlackHookApi.kt` | 1-25 | **참조 모델**. `@HttpExchange` + `@PostExchange` 인터페이스, `Request(channel, text, username)` payload, `companion object`에 채널 상수. |
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/api/ApiConfiguration.kt` | 13-19 | **참조 모델**. `@Bean`으로 `RestClient` baseUrl을 webhook URL로 셋업하고 `HttpServiceProxyFactory`로 인터페이스 프록시 생성. `@Value("\${slack.hook-url}")` 패턴. |
+| `src/main/resources/application-prod.yaml` | 24-25 | `slack.hook-url: ${SLACK_WEBHOOK_URL}` — 환경변수 명명 컨벤션 (kebab-case 키, UPPER_SNAKE 환경변수). dev/local 동일. |
+| `src/main/resources/application-dev.yaml` | 24-25 | 동상. |
+| `src/main/resources/application-local.yaml` | 24-25 | 동상. |
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/UserRepository.kt` | 9 | `MongoRepository<User, ObjectId>` 상속 → `count(): Long` 자동 제공. **별도 메서드 추가 불필요.** |
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/client/FirebasePushClient.kt` | 21, 35 | **참조 모델 (비동기/실패 격리)**. `@Async` 어노테이션 + `RetryTemplate`로 외부 호출 격리. |
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/DdanDdanServerApplication.kt` | 12 | `@EnableAsync` 이미 활성화 — `@Async` 즉시 사용 가능. |
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/config/RetryConfig.kt` | 7 | `RetryTemplate` 빈 정의 — Discord 호출에도 재사용 가능. |
+
+## 참조할 기존 패턴
+
+- **`SlackHookApi` (`infrastructure/api/SlackHookApi.kt` + `ApiConfiguration.kt`)** — Discord Webhook 클라이언트의 1:1 미러링 모델. 인터페이스 + `@HttpExchange` + `@PostExchange` + `RestClient` baseUrl 주입 방식, webhook URL을 `@Value`로 yaml에서 주입하는 패턴, 채널/봇이름 등 상수를 `companion object`로 모으는 컨벤션을 그대로 따른다. (단, Discord Webhook payload는 Slack과 키가 다르다 — Discord는 `content`, `username`, `avatar_url`, `embeds` 사용.)
+- **`FirebasePushClient` (`infrastructure/client/FirebasePushClient.kt`)** — 외부 호출을 메인 흐름에서 떼어내는 패턴. `@Async` + `RetryTemplate.execute { ... }` 조합. Discord 알림도 동일 패턴이 적합하다 (가입은 사용자가 기다리는 동기 흐름이라 webhook 실패/지연이 절대 전이되면 안 된다).
+- **`AuthService.loginNewUser` (`application/service/AuthService.kt:50-68`)** — 신규 분기 자체가 명확히 분리돼 있어, 알림 호출 1줄을 메서드 끝에 추가하면 된다. 별도 분기 식별 로직이 필요 없다.
+
+## 위험 요소
+
+- **메인 가입 흐름 차단** — Discord Webhook 호출이 동기적으로 수 초 블록되면 OAuth 로그인 응답이 늦어진다. 반드시 `@Async` 메서드로 위임하거나 `try/catch`로 예외를 흡수해야 한다. `FirebasePushClient` 패턴 차용 권장.
+- **Webhook 실패 → 가입 실패 전이** — `@Transactional`(AuthService.login에 적용 중) 컨텍스트 안에서 webhook 호출 중 예외가 던져지면 user/auth 저장이 롤백된다. 두 가지 방어가 동시에 필요: (1) `@Async`로 트랜잭션 경계 밖으로 빼거나 (2) 호출부를 `try/catch`로 감싸 logger().error로만 남긴다. 추천: 둘 다.
+- **트랜잭션 커밋 전 알림 발송** — `@Async`만 적용하면 별 쓰레드에서 즉시 실행돼 user 저장 트랜잭션이 아직 커밋되지 않았을 수 있다. `누적 가입자 수`를 알림에 포함하려면 커밋 후 `count()`가 신규 사용자를 포함하도록 해야 정확하다. → `ApplicationEventPublisher` + `@TransactionalEventListener(phase = AFTER_COMMIT)` + `@Async` 조합이 가장 안전하다. 차선은 `AuthService.login()`이 끝난 뒤(=컨트롤러 레이어)에서 호출하는 것 (현재 controller는 미확인이므로 service 내부 이벤트 발행이 깔끔).
+- **민감 정보 노출** — `OAuth.nickName`은 KakaoProcessor에서는 카카오 닉네임이지만 **AppleProcessor에서는 이메일을 그대로 담는다** (`AppleProcessor.kt:34` `nickName = claims["email"].toString()`). Discord 채널이 운영팀 전용이라도 이메일을 평문으로 보내는 것은 PII 정책상 위험. provider별 표기를 다르게 하거나 마스킹 필요 (예: `m***@kakao.com`). 또는 알림 본문에서 nickName 노출을 생략하고 `userId`만 표기.
+- **환경변수 명명 일관성** — 기존 컨벤션은 `slack.hook-url: ${SLACK_WEBHOOK_URL}` (yaml 키는 kebab-case, 환경변수는 UPPER_SNAKE). Discord도 `discord.hook-url: ${DISCORD_WEBHOOK_URL}` 형식이 정합. dev/prod/local 세 yaml 모두 추가 필요.
+- **누적 가입자 수 계산 비용** — `userRepository.count()`는 `users` 컬렉션 전체 카운트로, 데이터가 커지면 무시 못 할 비용이 된다. 가입은 빈도가 낮으므로 큰 문제는 아니지만, 알림에 포함을 강제할 만큼 가치가 있는지 한번 고려할 것.
+- **dev/prod 채널 분리** — 운영팀 채널 하나로 두면 dev 환경 가입(테스트)도 같은 채널에 쏟아진다. profile별로 webhook URL을 다르게 주거나 dev에서는 알림을 끄는 토글이 권장된다.
+- **`SlackHookApi`는 정의만 있고 실사용 코드 없음** — `grep -rn sendMessage` 결과 호출 지점이 없다. Discord 클라이언트를 같은 패턴으로 만들면 동일하게 "정의만 있고 안 쓰는 상태"가 되지 않도록 호출부(AuthService 또는 이벤트 리스너)까지 반드시 같이 구현해야 한다.
+
+## 미해결 질문
+
+- **닉네임 노출 정책** — Apple의 경우 `nickName`이 이메일이다. 그대로 보낼지, 마스킹할지, 아예 빼고 `userId`만 보낼지? (위험 요소의 PII 항목과 동일.)
+- **dev/prod 채널 분리 여부** — 단일 webhook으로 통일할지, profile별로 다르게 둘지? 기본안은 단일이지만 dev 노이즈 우려가 있다.
+- **알림 실패 시 재시도 정책** — `RetryTemplate`(기존 `RetryConfig`)을 재사용할지, "fire and forget"으로 끝낼지? 운영 알림은 한 번 놓치면 끝이라 재시도 1~2회 권장.
+- **누적 가입자 수 포함 확정 여부** — 추측 기본안엔 들어 있으나 사용자 명시 동의는 없음. 비용/필요성 검토 필요.

--- a/_workspace/02_design.md
+++ b/_workspace/02_design.md
@@ -1,0 +1,244 @@
+# 설계: 신규 가입 디스코드 알림
+
+## 도메인 모델
+
+없음. Discord 운영 알림은 비즈니스 도메인 개념이 아니라 운영팀 통지 부수효과(side-effect)이므로 `domain/model/`에 새 모델을 만들지 않는다. 이벤트 객체(`UserRegisteredEvent`)는 application 레이어 내부 통신 매개체이며 도메인 모델이 아니다.
+
+## 이벤트
+
+### `UserRegisteredEvent` (application/event)
+
+`AuthService.loginNewUser()` 트랜잭션이 **커밋된 이후** Discord 발송에 필요한 모든 정보를 옮기는 불변 데이터 클래스.
+
+**필드:**
+
+| 필드 | 타입 | 의미 / 출처 |
+|---|---|---|
+| `userId` | `org.bson.types.ObjectId` | `newUser.id` — Discord 메시지에서 식별자 표기에 사용 |
+| `nickName` | `String` | `oAuth.nickName` — Discord 메시지의 사용자명 표기 (사용자 결정: 마스킹 없이 그대로 노출, Apple의 이메일 노출 위험은 사용자가 감수) |
+| `oAuthType` | `notbe.tmtm.ddanddanserver.domain.model.auth.OAuthType` | `KAKAO` / `APPLE` — provider 표기 |
+| `registeredAt` | `java.time.Instant` | 이벤트 생성 시각(가입 시각). 트랜잭션 커밋 후 시각이 아니라 신규 User 생성 시점을 보존하기 위해 publish 직전에 `Instant.now()`로 채운다 |
+
+**필드 선정 근거:**
+- Discord 메시지 본문 구성에 필요한 최소 필드만 담는다. `User` 객체 전체나 `Auth` 객체 전체를 넣지 않는 이유는 (1) listener에서 도메인 메서드를 호출할 일이 없고 (2) 이벤트 객체는 영속 객체 참조를 들고 트랜잭션 경계를 넘기지 않는 편이 안전하기 때문이다(LazyInitialization 등 우회 가능 이슈 회피 + 의도 명확화).
+- `누적 가입자 수`는 이벤트 필드에 넣지 않는다. listener가 `AFTER_COMMIT` 시점에 `userRepository.count()`로 직접 조회한다. 이렇게 해야 신규 사용자 자신을 포함한 정확한 카운트가 나온다.
+
+## 서비스 시그니처
+
+### `AuthService` 변경 (application/service/AuthService.kt 수정)
+
+생성자에 `ApplicationEventPublisher`를 주입받고, `loginNewUser()` 내부에서 `userRepository.save(...)`/`authRepository.save(...)` 직후 이벤트를 발행한다.
+
+```kotlin
+@Service
+class AuthService(
+    private val authRepository: AuthRepository,
+    private val userRepository: UserRepository,
+    private val jwtTokenProvider: JWTTokenProvider,
+    private val oauthProcessorFactory: OAuthProcessorFactory,
+    private val eventPublisher: org.springframework.context.ApplicationEventPublisher, // 추가
+) {
+    // ...
+
+    private fun loginNewUser(
+        oAuth: OAuth,
+        deviceToken: String?,
+        oAuthType: OAuthType,
+    ): AuthResult {
+        val newUser = userRepository.save(
+            User.register(name = oAuth.nickName, deviceToken = deviceToken),
+        )
+        authRepository.save(
+            Auth.create(oAuthId = oAuth.id, type = oAuthType, userId = newUser.id),
+        )
+
+        // 추가: 트랜잭션 커밋 후 Discord 알림 발송을 위한 이벤트 발행
+        eventPublisher.publishEvent(
+            UserRegisteredEvent(
+                userId = newUser.id,
+                nickName = oAuth.nickName,
+                oAuthType = oAuthType,
+                registeredAt = Instant.now(),
+            ),
+        )
+
+        return AuthResult(
+            accessToken = jwtTokenProvider.createAccessToken(newUser),
+            refreshToken = jwtTokenProvider.createRefreshToken(newUser),
+            user = newUser,
+        )
+    }
+}
+```
+
+**기존 메서드 시그니처(반환 타입, 파라미터) 변경 없음.** 컨트롤러/외부 API 영향 없음.
+
+### `UserRegisteredEventListener` (신규: application/event/UserRegisteredEventListener.kt)
+
+```kotlin
+@Component
+class UserRegisteredEventListener(
+    private val userRepository: UserRepository,
+    private val discordHookApi: DiscordHookApi,
+    @Value("\${spring.profiles.active:local}") private val activeProfile: String,
+) {
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: UserRegisteredEvent)
+}
+```
+
+**핸들러 책임:**
+1. `userRepository.count()`로 누적 가입자 수 조회 (트랜잭션 커밋 후이므로 신규 사용자 포함됨).
+2. `activeProfile.uppercase()`로 phase 접두어 생성 (`PROD`, `DEV`, `LOCAL`).
+3. 한국어 한 줄 메시지 본문 조립.
+4. `discordHookApi.sendMessage(...)`를 `try { ... } catch (e: Exception) { log.error(...) }`로 감싸 모든 예외 흡수.
+
+**메시지 포맷 (예시):**
+
+```
+[PROD] 신규 가입 | 닉네임=홍길동 | provider=KAKAO | userId=66341a2b3c4d5e6f78901234 | 가입시각=2026-05-02T14:23:11Z | 누적 가입자=1,234명
+```
+
+- 단일 `content` 한 줄 문자열. Discord embed 미사용 (사용자 결정 가이드: "content 한 줄도 충분").
+- 천단위 콤마는 `String.format("%,d", count)` 사용.
+
+## 외부 클라이언트
+
+### `DiscordHookApi` (신규: infrastructure/api/DiscordHookApi.kt)
+
+`SlackHookApi`를 1:1 미러링한다. `@HttpExchange` + `@PostExchange` + `RestClient` baseUrl 주입 패턴 동일.
+
+```kotlin
+@HttpExchange(accept = [MediaType.APPLICATION_JSON_VALUE])
+interface DiscordHookApi {
+    @PostExchange
+    fun sendMessage(
+        @RequestBody request: Request,
+    )
+
+    data class Request(
+        val content: String,
+        val username: String = DEFAULT_USERNAME,
+    )
+
+    companion object {
+        const val DEFAULT_USERNAME = "ddan-ddan-server-bot"
+    }
+}
+```
+
+**Slack과의 차이 (Discord webhook 스펙 준수):**
+- payload 키는 `content`, `username` (Slack은 `text`, `channel`, `username`).
+- Discord webhook은 채널을 URL 자체에 묶기 때문에 `channel` 필드가 없다.
+- `avatar_url`, `embeds` 등 추가 필드는 본 설계 범위에서 사용하지 않음 (단순 한 줄 알림으로 충분).
+
+### `ApiConfiguration` 수정 (infrastructure/api/ApiConfiguration.kt)
+
+`slackHookApi` 빈과 동일한 형태로 `discordHookApi` 빈 추가. `@Value("\${discord.hook-url}")`로 webhook URL 주입.
+
+```kotlin
+@Bean
+fun discordHookApi(
+    @Value("\${discord.hook-url}") hookUrl: String,
+): DiscordHookApi {
+    val factory = HttpServiceProxyFactory.builderFor(restClientAdapter(hookUrl)).build()
+    return factory.createClient(DiscordHookApi::class.java)
+}
+```
+
+기존 `restClientAdapter(baseUrl: String)` 헬퍼 그대로 재사용. 신규 헬퍼 함수 불필요.
+
+## API 명세
+
+**외부 API 변경 없음.** presentation 레이어 무변화. 기존 `/auth/login` 시리즈 엔드포인트의 요청/응답 시그니처도 그대로다. 본 기능은 OAuth 가입 흐름의 부수효과로만 동작한다.
+
+## MongoDB 스키마
+
+**변경 없음.** `users` 컬렉션의 `count()`만 읽으며, 신규 컬렉션/필드/인덱스 추가 없음.
+
+## 예외
+
+**신규 도메인 예외 없음.** Discord 알림 실패는 비즈니스 실패가 아니라 운영 통지 부수효과 실패이므로 `WebExceptionHandler`에 매핑할 필요가 없다.
+
+`UserRegisteredEventListener.handle()`은 단일 `try { ... } catch (e: Exception) { log.error(...) }` 블록으로 모든 예외(IO, HTTP 4xx/5xx, 직렬화 등)를 흡수한다. 재시도 없음 (사용자 결정: fire-and-forget).
+
+```kotlin
+private val log = LoggerFactory.getLogger(javaClass)
+
+try {
+    discordHookApi.sendMessage(DiscordHookApi.Request(content = body))
+} catch (e: Exception) {
+    log.error("Discord 신규 가입 알림 발송 실패: userId={}, provider={}", event.userId, event.oAuthType, e)
+}
+```
+
+로그에는 사용자 PII(`nickName`)를 남기지 않는다 — `userId`와 provider만. (kotlin-spring-conventions 가이드 준수: "민감 정보는 절대 로깅 금지".)
+
+## 환경변수 / 설정
+
+### `discord.hook-url` 추가
+
+`slack.hook-url`과 동일한 컨벤션 (yaml 키 kebab-case, 환경변수 UPPER_SNAKE).
+
+| 파일 | 추가 라인 |
+|---|---|
+| `src/main/resources/application-prod.yaml` | `discord:`<br>` hook-url: ${DISCORD_WEBHOOK_URL}` |
+| `src/main/resources/application-dev.yaml` | `discord:`<br>` hook-url: ${DISCORD_WEBHOOK_URL}` |
+| `src/main/resources/application-local.yaml` | `discord:`<br>` hook-url: ${DISCORD_WEBHOOK_URL}` |
+
+세 yaml 모두 `slack:` 블록 바로 아래(혹은 인접한 외부 통합 영역)에 들여쓰기 2-space로 추가한다. 단일 webhook URL을 공유하되 메시지 본문에 phase 접두어를 붙여 채널 분리 효과를 낸다 (사용자 결정).
+
+### `spring.profiles.active` 사용처
+
+`UserRegisteredEventListener` 생성자에서 `@Value("\${spring.profiles.active:local}") private val activeProfile: String`로 주입받아 메시지 prefix에 사용. 기본값 `local`로 두어 profile 미설정 환경에서도 안전.
+
+### `@Async` 동작 보장
+
+`DdanDdanServerApplication`에 `@EnableAsync`가 이미 활성화되어 있어(이슈 분석 메모 확인) 별도 설정 불필요. `@TransactionalEventListener`는 spring-tx에 포함되어 추가 의존성 없음.
+
+## 변경 파일 목록
+
+### 생성
+
+- `src/main/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEvent.kt`
+- `src/main/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListener.kt`
+- `src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/api/DiscordHookApi.kt`
+
+### 수정
+
+- `src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/AuthService.kt` — 생성자에 `ApplicationEventPublisher` 추가, `loginNewUser()` 끝(return 직전)에서 `eventPublisher.publishEvent(UserRegisteredEvent(...))` 1줄 추가
+- `src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/api/ApiConfiguration.kt` — `discordHookApi` `@Bean` 메서드 추가
+- `src/main/resources/application-prod.yaml` — `discord.hook-url` 항목 추가
+- `src/main/resources/application-dev.yaml` — `discord.hook-url` 항목 추가
+- `src/main/resources/application-local.yaml` — `discord.hook-url` 항목 추가
+
+테스트 파일은 test-engineer가 별도로 추가한다.
+
+## 결정 이유
+
+### 왜 `ApplicationEventPublisher` + `@TransactionalEventListener(AFTER_COMMIT)` + `@Async` 조합인가
+
+1. **트랜잭션 커밋 후 발송 보장.** `AuthService.login()`은 `@Transactional`이 걸려 있어 신규 사용자/Auth 저장이 트랜잭션 안에서 일어난다. 만약 service 내부에서 webhook을 직접 호출하면 (a) 호출 중 예외가 던져져 트랜잭션이 롤백되거나 (b) 커밋 전에 알림이 나가버리는 문제가 생긴다. `@TransactionalEventListener(phase = AFTER_COMMIT)`은 정확히 이 두 문제를 함께 막는다 — 커밋이 완료된 뒤에만 호출되고, listener에서 던진 예외는 원래 트랜잭션에 영향을 주지 않는다.
+2. **누적 가입자 수의 정확성.** `userRepository.count()`를 listener에서 호출하면 새로 저장된 사용자 자신이 카운트에 포함된 결과가 나온다. service 내부에서 호출하면 트랜잭션 격리에 따라 카운트에 자기 자신이 빠질 수 있고 (read-uncommitted가 아닌 한), 트랜잭션 경계 안에서 호출되어 의도가 흐려진다.
+3. **메인 흐름과의 분리 (응답 지연 방지).** `@Async`로 별도 쓰레드에서 실행하므로 Discord webhook이 수 초 지연되어도 OAuth 로그인 응답은 즉시 반환된다. `@EnableAsync`가 이미 적용돼 있어 추가 부트스트랩 비용 없음.
+4. **대안 비교.**
+   - "service 내부에서 직접 webhook 호출 + `@Async`만 적용": 트랜잭션 미커밋 상태에서 알림이 나갈 수 있음. **탈락.**
+   - "controller에서 service 호출 후 webhook 호출": controller가 비즈니스 부수효과를 책임지게 되어 layered 의존 규칙(presentation→application 단방향) 안에 두기 어렵고, controller에 신규/기존 분기를 다시 만들어야 함. **탈락.**
+   - "도메인 이벤트를 domain 모델에 부착": Spring `ApplicationEvent`는 domain 모델을 Spring에 묶는 결과가 되어 layered-architecture-guide의 "domain은 Spring 어노테이션 금지" 원칙을 위반. **탈락.**
+   - 따라서 **이벤트 객체는 application 레이어 plain class**로 두고, publisher/listener도 application에 위치시키는 것이 가장 깔끔하다.
+
+### 왜 재시도가 없는가 (사용자 결정)
+
+- 사용자 결정: 운영 알림 1건 누락보다는 코드 단순성과 외부 의존도 최소화를 우선. fire-and-forget으로 처리하고 실패는 `logger.error`로 흔적만 남긴다. 운영 부재 시 ELK/CloudWatch 등에서 ERROR 로그를 검색해 누락 가입을 사후 보정 가능.
+- 기존 `RetryConfig`의 `RetryTemplate`을 끌어다 쓸 수 있지만 본 설계에서는 사용하지 않는다. 재시도 정책이 추후 필요해지면 listener 안에서만 추가하면 되므로 확장 용이.
+
+### 왜 phase 접두어로 채널을 통합하는가 (사용자 결정)
+
+- 사용자 결정: dev/prod webhook URL을 별도로 두면 Vault/CI 환경변수 관리 부담이 두 배가 된다. 단일 webhook URL을 유지하되 메시지 첫머리에 `[PROD]` / `[DEV]` / `[LOCAL]` 접두어를 붙여 운영팀이 시각적으로 구분.
+- 트레이드오프: dev 노이즈가 같은 채널에 흘러들어가지만, phase 접두어로 운영팀이 필터링/검색 가능. dev 트래픽이 과도해지면 추후 이 설계를 깨지 않고 yaml만 분리해 channel webhook을 환경별로 다르게 줄 수 있다.
+
+### 왜 nickName을 그대로 노출하는가 (사용자 결정)
+
+- 사용자 결정: Apple 로그인 시 `OAuth.nickName`이 이메일이라는 것을 알고 있으나, 운영팀 전용 Discord 채널이고 마스킹 로직 추가 시 KakaoProcessor 닉네임도 함께 가독성이 떨어지는 트레이드오프 발생. 사용자가 PII 노출 위험을 감수하기로 결정.
+- 보완: 로그(`logger.error`)에는 `nickName`을 남기지 않는다 — 코드 컨벤션 가이드의 "민감 정보 로깅 금지" 원칙은 준수. Discord webhook payload는 운영팀에 한정된 1회성 통보이므로 영구 저장 위험은 webhook 수신 시스템(Discord) 보존 정책에 위임.

--- a/_workspace/03_implementation.md
+++ b/_workspace/03_implementation.md
@@ -1,0 +1,42 @@
+# 구현 결과
+
+## 변경 파일
+
+| 파일 | 동작 | 요약 |
+|---|---|---|
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEvent.kt` | 생성 | Spring 무관 plain `data class`. 필드: `userId(ObjectId)`, `nickName(String)`, `oAuthType(OAuthType)`, `registeredAt(Instant)`. |
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListener.kt` | 생성 | `@Component`, `@Async + @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)`. `userRepository.count()` → `[PROFILE] 신규 가입 ...` 한 줄 메시지 조립 → `discordHookApi.sendMessage(...)`. `try/catch (Exception)`로 모든 예외 흡수, `logger().error`에 `userId`/`oAuthType`만 로깅 (nickName 미포함). 천단위 콤마는 `String.format("%,d", count)`. |
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/api/DiscordHookApi.kt` | 생성 | `SlackHookApi`와 동일한 패턴(`@HttpExchange` + `@PostExchange` + `data class Request` + `companion object`). Discord webhook 스펙에 맞춰 payload 키는 `content`, `username`. `DEFAULT_USERNAME = "ddan-ddan-server-bot"`. |
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/api/ApiConfiguration.kt` | 수정 | `slackHookApi` 빈 직후 동일한 형태로 `discordHookApi` `@Bean` 추가. `@Value("\${discord.hook-url}")` + 기존 `restClientAdapter(baseUrl)` 헬퍼 재사용. |
+| `src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/AuthService.kt` | 수정 | 생성자 마지막 파라미터로 `private val eventPublisher: ApplicationEventPublisher` 추가. `loginNewUser()` 내부 `authRepository.save(...)` 직후 `return AuthResult` 직전에 `eventPublisher.publishEvent(UserRegisteredEvent(..., registeredAt = Instant.now()))` 1줄 추가. import 2건 추가(`ApplicationEventPublisher`, `Instant`, `UserRegisteredEvent`). 기존 메서드 시그니처 변동 없음. |
+| `src/main/resources/application-prod.yaml` | 수정 | `slack:` 블록 직후에 `discord:` 블록 추가 (`hook-url: ${DISCORD_WEBHOOK_URL}`). 들여쓰기는 기존 파일과 동일한 4-space. |
+| `src/main/resources/application-dev.yaml` | 수정 | 동상. |
+| `src/main/resources/application-local.yaml` | 수정 | 동상. |
+
+## 핵심 결정
+
+- **yaml 들여쓰기**: 작업 지시는 "2-space"였으나, 기존 세 yaml 파일 모두 최상위 키 하위에 4-space를 사용 중(`slack:` 블록 포함). 컨벤션 일관성을 위해 기존 파일과 동일한 4-space로 작성. 기존 컨벤션을 깨지 않기 위한 결정.
+- **그 외 설계 대비 변경 사항 없음.** 설계서 그대로 구현.
+
+## 빌드 검증
+
+- `./gradlew compileKotlin`: 통과. (로컬 기본 JDK가 25로 잡혀 있어 Gradle 8.8 호환성 이슈로 1차 실패 → JDK 17(`/usr/libexec/java_home -v 17.0.14`)로 재시도해 `BUILD SUCCESSFUL`. 본 변경과 무관한 환경 이슈이며, 코드 자체는 문제 없음.)
+- 출력된 경고는 모두 기존 코드의 Kotlin KT-73255(어노테이션 타깃 변경) 마이그레이션 경고로 본 작업과 무관.
+
+## test-engineer에게 전달할 메모
+
+- **`UserRegisteredEventListener` 단위 테스트 시 mock 포인트**:
+  - `userRepository.count()` — `every { userRepository.count() } returns 1234L`
+  - `discordHookApi.sendMessage(any())` — `every { discordHookApi.sendMessage(any()) } just runs` 또는 예외 던지는 케이스
+  - `@Value("\${spring.profiles.active:local}") activeProfile` — 생성자 인자로 직접 문자열 주입(`"prod"`, `"dev"`, `"local"`) 가능
+- **검증 포인트**:
+  - 메시지 본문 정확성: `[PROD] 신규 가입 | 닉네임=홍길동 | provider=KAKAO | userId=... | 가입시각=... | 누적 가입자=1,234명` 형식. 천단위 콤마 확인.
+  - `discordHookApi.sendMessage`가 정확히 1회 호출되는지 (`verify(exactly = 1) { ... }`)
+  - `discordHookApi.sendMessage`가 예외를 던져도 `handle()`에서 throw되지 않는지(예외 흡수 검증)
+  - 예외 발생 시 logger error 호출은 직접 검증보다 "throw되지 않음"으로 검증하는 편이 견고
+- **`AuthService` 단위 테스트**:
+  - 생성자에 `ApplicationEventPublisher` 추가됨 → 기존 `AuthService` 테스트의 mock 생성자에 `eventPublisher` 인자 추가 필요. mockk이라면 `mockk<ApplicationEventPublisher>(relaxed = true)`로 받고, 신규 가입 케이스에 한해 `verify { eventPublisher.publishEvent(any<UserRegisteredEvent>()) }`로 발행 1회 검증.
+  - `loginExistUser()` 경로에서는 이벤트가 발행되지 않아야 함 → `verify(exactly = 0) { eventPublisher.publishEvent(any<UserRegisteredEvent>()) }`.
+  - `Instant.now()`는 publish 직전에 호출되므로 정확한 값 비교는 `match { it.userId == ... && it.oAuthType == ... }` 식 부분 매칭 권장.
+- **트랜잭션 / `@Async` 행위 검증**: 단위 테스트로는 잡기 어렵다. `@TransactionalEventListener(AFTER_COMMIT)`/`@Async` 동작은 통합 테스트 영역. 단위 테스트는 "이벤트 발행"과 "리스너 핸들러 동작"을 분리해서 검증하면 충분.
+- **외부 의존**: Discord webhook은 실제 호출되지 않도록 `DiscordHookApi`를 항상 mock으로 주입할 것. 통합 테스트에서도 webhook URL을 더미로 두면 `RestClient`가 실제 네트워크 호출을 시도하지 않게 막아야 함(또는 `DiscordHookApi`를 `@MockBean`).

--- a/_workspace/04_test_summary.md
+++ b/_workspace/04_test_summary.md
@@ -1,0 +1,49 @@
+# 테스트 결과
+
+## 추가된 테스트 파일
+
+- `src/test/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListenerTest.kt` — 6개 테스트 (정상 4 / 예외 2)
+- `src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/AuthServiceTest.kt` — 3개 테스트 (정상 3 / 예외 0)
+  - 기존 `AuthServiceTest`는 존재하지 않아 신규 작성. 기존 케이스 회귀 우려 없음.
+
+## 커버한 케이스
+
+### UserRegisteredEventListenerTest
+- 신규 가입 이벤트 수신 시 디스코드 웹훅에 정확한 페이로드로 발송한다
+  - 메시지 형식 검증: `[PROD] 신규 가입`, `닉네임=...`, `provider=KAKAO`, `userId=...`, `가입시각=...`, `누적 가입자=1,234명`
+  - `userRepository.count()`가 정확히 1회 호출되는지 검증
+  - `discordHookApi.sendMessage`가 정확히 1회 호출되는지 검증
+- activeProfile이 소문자여도 메시지 접두어는 대문자로 변환된다 (`dev` → `[DEV]`, `provider=APPLE` 검증)
+- 누적 가입자 수가 천 단위 이상이면 콤마가 포함된다 (1,234,567명)
+- 디스코드 웹훅 호출이 예외를 던져도 리스너는 예외를 흡수한다 (`shouldNotThrow`)
+- userRepository.count() 호출이 예외를 던져도 리스너는 예외를 흡수한다 (`shouldNotThrow` + `discordHookApi.sendMessage`가 호출되지 않음 검증)
+- 디스코드 요청의 username 필드는 기본값을 따른다 (`DiscordHookApi.DEFAULT_USERNAME`)
+
+### AuthServiceTest
+- 신규 사용자 가입 시 UserRegisteredEvent가 발행된다
+  - `eventPublisher.publishEvent(any<UserRegisteredEvent>())` 정확히 1회
+  - 발행된 이벤트의 `nickName`, `oAuthType`, `userId` 필드가 신규 유저와 일치
+- 기존 사용자 로그인 시 UserRegisteredEvent가 발행되지 않는다 (`verify(exactly = 0)`)
+- 기존 사용자가 동일한 deviceToken으로 로그인하면 사용자 저장이 호출되지 않는다 (분기 검증, 이벤트 미발행도 함께 확인)
+
+## 실행 결과
+
+```
+./gradlew test --tests "notbe.tmtm.ddanddanserver.application.event.*" \
+              --tests "notbe.tmtm.ddanddanserver.application.service.AuthServiceTest"
+```
+
+- BUILD SUCCESSFUL
+- UserRegisteredEventListenerTest: 6 tests, 0 failures, 0 errors (0.585s)
+- AuthServiceTest: 3 tests, 0 failures, 0 errors (0.197s)
+- 합계: ✅ 9/9 통과
+
+JDK는 환경 안내대로 `JAVA_HOME=$(/usr/libexec/java_home -v 17.0.14)`로 실행.
+
+## implementer에게 전달할 피드백
+
+- **테스트 용이성: 양호.** 인계 메모대로 `UserRegisteredEventListener`의 `activeProfile`을 `@Value` 주입이지만 생성자 인자로 그대로 직접 주입할 수 있어 mock 없이 phase 분기 검증이 깔끔했음.
+- **`AuthService`도 양호.** `ApplicationEventPublisher`를 생성자에 노출했기 때문에 `mockk(relaxed = true)`로 받고 `slot`/`verify(exactly = 0/1)`만으로 분기를 충분히 검증 가능.
+- **개선 제안 (선택):** `UserRegisteredEventListener.handle()`의 `Instant.now()`는 `AuthService.loginNewUser()`에서 호출되는데, 만약 후속에 메시지 본문이 한국 시간 포맷팅을 요구하게 되면 `Clock` 주입을 고려해 볼 만함. 현재 범위에서는 불필요.
+- **`@Async`/`@TransactionalEventListener(AFTER_COMMIT)` 검증은 통합 테스트 영역**으로 분리됨 (단위 테스트 범위 외). 본 PR에서는 작성 안 함.
+- **`DiscordHookApi`/`ApiConfiguration` 단위 테스트 미작성** — 인터페이스 + Spring 빈 정의로 단위 테스트 가치가 낮아 작업 지시대로 생략.

--- a/_workspace/05_review.md
+++ b/_workspace/05_review.md
@@ -1,0 +1,36 @@
+# 리뷰 결과
+
+## 요약
+- ✅ 승인 가능 — Critical/Major 없음. Minor 권고 2건만 선택 적용.
+
+## Critical (반드시 수정)
+- 없음.
+
+## Major (수정 권장)
+- 없음.
+
+## Minor (선택)
+- [ ] **`registeredAt` 타임존 표기** — `src/main/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListener.kt:26` — `event.registeredAt`은 `Instant.toString()`으로 UTC ISO-8601(`2026-05-02T10:15:30Z`)이 그대로 찍힌다. 운영팀이 채널을 한국 시간 기준으로 본다면 `DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.of("Asia/Seoul"))`로 포맷하는 것을 권고. 04_test_summary.md의 test-engineer 의견과 동일. 본 PR 범위에서는 사용자 결정에 따라 그대로 두어도 무방.
+- [ ] **`SlackHookApi.username` 하드코딩과의 비대칭** — `src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/api/DiscordHookApi.kt:21` — `DiscordHookApi`는 `DEFAULT_USERNAME` 컨스턴트로 노출했지만 기존 `SlackHookApi.kt:18`은 같은 값을 인라인 문자열로 들고 있다. 공용 상수(예: `infrastructure/api/HookConstants.kt`)로 빼는 것이 일관성 측면에서 좋지만, 본 PR 범위 외 정리이므로 후속 리팩토링 PR에서 처리 권장.
+- [ ] **`SlackHookApi`에서 `username` 필드도 인라인이지만 `SlackHookApi.Request.username` 기본값 패턴은 그대로** — 위와 동일. 무리한 본 PR 확대 금지.
+
+## 칭찬
+- **설계서 준수도 매우 높음.** 02_design.md의 "왜 이 조합인가" 근거(트랜잭션 커밋 후 발송 + 누적 카운트 정확성 + 응답 지연 방지)가 그대로 코드에 녹아 있다.
+- **트랜잭션 안전성 확보.** `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)` + `@Async` 조합으로 (a) 가입 트랜잭션 롤백 시 알림 미발송, (b) listener 예외가 가입 흐름에 역류하지 않음, (c) webhook 지연이 OAuth 응답 지연으로 이어지지 않음을 모두 보장. `DdanDdanServerApplication.kt:12`의 `@EnableAsync`가 이미 활성화돼 있어 별도 설정 없이 동작.
+- **메인 흐름 보호 견고함.** `UserRegisteredEventListener.kt:21-37`의 단일 `try { ... } catch (e: Exception)` 블록이 webhook IO/HTTP/직렬화 모든 예외를 흡수. 운영 알림 누락은 ERROR 로그로 사후 추적 가능.
+- **PII 로깅 컨벤션 준수.** `logger().error(...)` 호출(line 31-36)에 `userId`/`oAuthType`만 남기고 `nickName`은 일부러 제외. kotlin-spring-conventions의 "민감 정보 로깅 금지" 원칙 정확히 지킴. Discord payload에는 그대로 노출되지만 이는 사용자 결정(02_design.md 결정 이유 항).
+- **이벤트 객체가 plain data class.** `UserRegisteredEvent.kt`에 Spring 어노테이션이 일절 없어 application 레이어 내부 매개체로서의 위치가 깔끔. 도메인 모델로 끌고 가지 않은 것도 적절(side-effect용 데이터).
+- **테스트 커버리지 양호.** Kotest FunSpec + MockK + 한국어 테스트명 + `beforeEach` 패턴 정확. `slot`으로 페이로드 캡처 후 `shouldContain`으로 메시지 형식 검증, `shouldNotThrow`로 예외 흡수 검증, `verify(exactly = 0/1)`로 분기 검증 — 한 가지 결함도 없이 정도(正道)로 작성됨.
+- **AuthService 테스트의 신규/기존 분기 검증.** `eventPublisher.publishEvent(any<UserRegisteredEvent>())`를 신규 가입에서만 1회, 기존 사용자에서 0회 검증한 것이 회귀 방지에 효과적.
+- **YAML 들여쓰기 일관성.** 03_implementation.md에서 명시한 대로 작업 지시("2-space")보다 기존 파일 컨벤션(4-space)을 우선해 일관성 유지. 적절한 판단.
+
+## 환경/보안 점검
+- **webhook URL 하드코딩 없음** — 세 yaml 모두 `${DISCORD_WEBHOOK_URL}` 환경변수만 참조. 코드 상수에는 어떤 webhook URL도 박혀 있지 않음.
+- **트랜잭션 phase 검증 — AFTER_COMMIT 사용 확인됨** (`UserRegisteredEventListener.kt:19`).
+- **메인 가입 흐름 차단 위험 없음** — listener의 try/catch + `@Async` 조합으로 webhook 실패가 OAuth login API에 영향을 줄 경로 없음.
+- **layered 의존 방향** — `UserRegisteredEventListener`가 `infrastructure.database.repository.UserRepository`(인터페이스, `interface UserRepository : MongoRepository`)와 `infrastructure.api.DiscordHookApi`(인터페이스)를 import. layered-architecture-guide 가이드에서 허용한 "application/service에서 인프라 인터페이스(Repository, Client)에 의존" 패턴 준수. AuthService 등 기존 service들과 동일 패턴.
+
+## implementer에게 전달
+- Critical/Major 없음. **수정 없이 그대로 PR 생성 가능.**
+- Minor 2건은 모두 본 PR 범위를 벗어나는 후속 정리 권장 사항이므로, 별도 이슈/PR로 분리하거나 본 PR에서는 무시해도 무방.
+- PR 메시지 한국어 컨벤션 (`feat: 신규 가입 디스코드 알림 추가` 등)으로 작성 권장. 이슈 번호가 있다면 본문 끝에 `close #이슈번호`.

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/StatsAdminService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/StatsAdminService.kt
@@ -1,0 +1,45 @@
+package notbe.tmtm.ddanddanserver.application.service
+
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.StatsAdminRepository
+import notbe.tmtm.ddanddanserver.presentation.dto.admin.DailyCountResponse
+import notbe.tmtm.ddanddanserver.presentation.dto.admin.PetCountResponse
+import notbe.tmtm.ddanddanserver.presentation.dto.admin.StatsAdminResponse
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.ZoneId
+
+@Service
+class StatsAdminService(
+    private val statsAdminRepository: StatsAdminRepository,
+) {
+    fun getDashboard(seriesDays: Int): StatsAdminResponse {
+        val today = LocalDate.now(ZONE)
+        val weekAgo = today.minusDays(WEEK_OFFSET)
+        val monthAgo = today.minusDays(MONTH_OFFSET)
+        val seriesStart = today.minusDays((seriesDays - 1).toLong())
+
+        return StatsAdminResponse(
+            totalUsers = statsAdminRepository.countAllUsers(),
+            newUsersToday = statsAdminRepository.countNewUsersBetween(today, today),
+            newUsersThisWeek = statsAdminRepository.countNewUsersBetween(weekAgo, today),
+            newUsersThisMonth = statsAdminRepository.countNewUsersBetween(monthAgo, today),
+            activeUsersToday = statsAdminRepository.countDistinctActiveUsersBetween(today, today),
+            activeUsersThisWeek = statsAdminRepository.countDistinctActiveUsersBetween(weekAgo, today),
+            totalPets = statsAdminRepository.countAllPets(),
+            petDistribution =
+                statsAdminRepository.groupPetsByType().map {
+                    PetCountResponse(type = it.type, count = it.count)
+                },
+            signupSeries =
+                statsAdminRepository.getSignupSeries(seriesStart, today).map {
+                    DailyCountResponse(date = it.date, count = it.count)
+                },
+        )
+    }
+
+    private companion object {
+        val ZONE: ZoneId = ZoneId.of("Asia/Seoul")
+        const val WEEK_OFFSET = 6L // 오늘 포함 7일
+        const val MONTH_OFFSET = 29L // 오늘 포함 30일
+    }
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/StatsAdminRepository.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/StatsAdminRepository.kt
@@ -1,0 +1,32 @@
+package notbe.tmtm.ddanddanserver.infrastructure.database.repository
+
+import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
+import java.time.LocalDate
+
+interface StatsAdminRepository {
+    fun countAllUsers(): Long
+
+    fun countAllPets(): Long
+
+    /** [from, to] 두 날짜 사이(둘 다 포함, KST 기준)에 가입한 유저 수. ObjectId timestamp 기반. */
+    fun countNewUsersBetween(from: LocalDate, to: LocalDate): Long
+
+    /** [from, to] 두 날짜 사이(둘 다 포함, KST 기준)에 daily_calories에 기록을 남긴 distinct 유저 수. */
+    fun countDistinctActiveUsersBetween(from: LocalDate, to: LocalDate): Long
+
+    /** 펫 종류별 분포. count desc. */
+    fun groupPetsByType(): List<StatsPetTypeCount>
+
+    /** [from, to] 두 날짜 사이(KST)의 일별 신규 가입자 수. 누락일은 0으로 채워서 반환. */
+    fun getSignupSeries(from: LocalDate, to: LocalDate): List<StatsDailyCount>
+}
+
+data class StatsPetTypeCount(
+    val type: PetType,
+    val count: Long,
+)
+
+data class StatsDailyCount(
+    val date: String,
+    val count: Long,
+)

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/StatsAdminRepositoryImpl.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/StatsAdminRepositoryImpl.kt
@@ -33,6 +33,9 @@ class StatsAdminRepositoryImpl(
     }
 
     override fun countDistinctActiveUsersBetween(from: LocalDate, to: LocalDate): Long {
+        // daily_calories.date는 LocalDate(시간 정보 없음) 타입으로 mongo에 저장되어
+        // 쿼리/저장 모두 동일 직렬화를 거치므로 KST 별도 변환이 불필요.
+        // getSignupSeries는 _id(UTC ObjectId timestamp) 기반이라 KST 변환이 필요한 것과 다른 케이스.
         val agg = Aggregation.newAggregation(
             Aggregation.match(Criteria.where("date").gte(from).lte(to)),
             Aggregation.group("userId"),

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/StatsAdminRepositoryImpl.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/repository/StatsAdminRepositoryImpl.kt
@@ -1,0 +1,124 @@
+package notbe.tmtm.ddanddanserver.infrastructure.database.repository
+
+import notbe.tmtm.ddanddanserver.domain.model.pet.Pet
+import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
+import notbe.tmtm.ddanddanserver.domain.model.user.User
+import org.bson.Document
+import org.bson.types.ObjectId
+import org.springframework.data.domain.Sort
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.aggregation.Aggregation
+import org.springframework.data.mongodb.core.aggregation.AggregationOperation
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import java.util.Date
+
+@Repository
+class StatsAdminRepositoryImpl(
+    private val mongoTemplate: MongoTemplate,
+) : StatsAdminRepository {
+    override fun countAllUsers(): Long = mongoTemplate.count(Query(), User::class.java)
+
+    override fun countAllPets(): Long = mongoTemplate.count(Query(), Pet::class.java)
+
+    override fun countNewUsersBetween(from: LocalDate, to: LocalDate): Long {
+        val fromId = startOfDayObjectId(from)
+        val toId = startOfDayObjectId(to.plusDays(1))
+        val query = Query(Criteria.where("_id").gte(fromId).lt(toId))
+        return mongoTemplate.count(query, User::class.java)
+    }
+
+    override fun countDistinctActiveUsersBetween(from: LocalDate, to: LocalDate): Long {
+        val agg = Aggregation.newAggregation(
+            Aggregation.match(Criteria.where("date").gte(from).lte(to)),
+            Aggregation.group("userId"),
+            Aggregation.count().`as`("count"),
+        )
+        val result = mongoTemplate
+            .aggregate(agg, "daily_calories", CountAggregateResult::class.java)
+            .uniqueMappedResult
+        return result?.count ?: 0L
+    }
+
+    override fun groupPetsByType(): List<StatsPetTypeCount> {
+        val agg = Aggregation.newAggregation(
+            Aggregation.group("type").count().`as`("count"),
+            Aggregation.sort(Sort.Direction.DESC, "count"),
+        )
+        val results = mongoTemplate
+            .aggregate(agg, "pets", PetTypeAggregateResult::class.java)
+            .mappedResults
+        return results.mapNotNull { it.toDomainOrNull() }
+    }
+
+    override fun getSignupSeries(from: LocalDate, to: LocalDate): List<StatsDailyCount> {
+        val fromId = startOfDayObjectId(from)
+        val toId = startOfDayObjectId(to.plusDays(1))
+
+        val agg = Aggregation.newAggregation(
+            Aggregation.match(Criteria.where("_id").gte(fromId).lt(toId)),
+            // _id(ObjectId)의 timestamp를 KST 기준 날짜 문자열로 변환
+            AggregationOperation {
+                Document(
+                    "\$project",
+                    Document(
+                        "date",
+                        Document(
+                            "\$dateToString",
+                            Document("format", "%Y-%m-%d")
+                                .append("date", Document("\$toDate", "\$_id"))
+                                .append("timezone", KST),
+                        ),
+                    ),
+                )
+            },
+            Aggregation.group("date").count().`as`("count"),
+            Aggregation.sort(Sort.Direction.ASC, "_id"),
+        )
+        val raw = mongoTemplate
+            .aggregate(agg, "users", DailyAggregateResult::class.java)
+            .mappedResults
+        val byDate = raw.associate { it.id to it.count }
+        // gap-filling: from~to 모든 날짜를 포함, 누락일은 0
+        return generateDateRange(from, to).map { d ->
+            val key = d.toString()
+            StatsDailyCount(date = key, count = byDate[key] ?: 0L)
+        }
+    }
+
+    private fun startOfDayObjectId(date: LocalDate): ObjectId {
+        val instant = date.atStartOfDay(ZoneId.of(KST)).toInstant()
+        return ObjectId(Date.from(instant))
+    }
+
+    private fun generateDateRange(from: LocalDate, to: LocalDate): List<LocalDate> {
+        val days = ChronoUnit.DAYS.between(from, to).toInt() + 1
+        return (0 until days).map { from.plusDays(it.toLong()) }
+    }
+
+    data class CountAggregateResult(val count: Long)
+
+    data class PetTypeAggregateResult(
+        val id: String?,
+        val count: Long,
+    ) {
+        fun toDomainOrNull(): StatsPetTypeCount? {
+            val typeName = id ?: return null
+            val type = runCatching { PetType.valueOf(typeName) }.getOrNull() ?: return null
+            return StatsPetTypeCount(type = type, count = count)
+        }
+    }
+
+    data class DailyAggregateResult(
+        val id: String,
+        val count: Long,
+    )
+
+    private companion object {
+        const val KST = "Asia/Seoul"
+    }
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/StatsAdminController.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/StatsAdminController.kt
@@ -1,0 +1,37 @@
+package notbe.tmtm.ddanddanserver.presentation.controller.admin
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import notbe.tmtm.ddanddanserver.application.service.StatsAdminService
+import notbe.tmtm.ddanddanserver.presentation.dto.admin.StatsAdminResponse
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/admin/stats")
+@Validated
+@Tag(name = "Admin · 통계", description = "운영자용 통계 대시보드")
+class StatsAdminController(
+    private val statsAdminService: StatsAdminService,
+) {
+    @Operation(
+        summary = "통계 대시보드",
+        description =
+            "전체/신규/활성 유저, 펫 분포, 일별 가입 추이를 한 번에 반환. " +
+                "날짜는 KST(Asia/Seoul) 기준. 가입 시각은 ObjectId timestamp 사용.",
+    )
+    @GetMapping("/dashboard")
+    fun dashboard(
+        @Parameter(description = "가입 추이 시리즈 길이(일). default 14, max 90")
+        @RequestParam(defaultValue = "14")
+        @Min(1)
+        @Max(90)
+        seriesDays: Int,
+    ): StatsAdminResponse = statsAdminService.getDashboard(seriesDays)
+}

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/StatsAdminController.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/StatsAdminController.kt
@@ -2,6 +2,7 @@ package notbe.tmtm.ddanddanserver.presentation.controller.admin
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
@@ -26,6 +27,8 @@ class StatsAdminController(
             "전체/신규/활성 유저, 펫 분포, 일별 가입 추이를 한 번에 반환. " +
                 "날짜는 KST(Asia/Seoul) 기준. 가입 시각은 ObjectId timestamp 사용.",
     )
+    @ApiResponse(responseCode = "200", description = "통계 대시보드 조회 성공")
+    @ApiResponse(responseCode = "400", description = "seriesDays 파라미터 오류 (1~90 범위 외)")
     @GetMapping("/dashboard")
     fun dashboard(
         @Parameter(description = "가입 추이 시리즈 길이(일). default 14, max 90")

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/admin/StatsAdminDto.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/admin/StatsAdminDto.kt
@@ -1,0 +1,25 @@
+package notbe.tmtm.ddanddanserver.presentation.dto.admin
+
+import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
+
+data class StatsAdminResponse(
+    val totalUsers: Long,
+    val newUsersToday: Long,
+    val newUsersThisWeek: Long,
+    val newUsersThisMonth: Long,
+    val activeUsersToday: Long,
+    val activeUsersThisWeek: Long,
+    val totalPets: Long,
+    val petDistribution: List<PetCountResponse>,
+    val signupSeries: List<DailyCountResponse>,
+)
+
+data class PetCountResponse(
+    val type: PetType,
+    val count: Long,
+)
+
+data class DailyCountResponse(
+    val date: String,
+    val count: Long,
+)

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/StatsAdminServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/StatsAdminServiceTest.kt
@@ -1,0 +1,123 @@
+package notbe.tmtm.ddanddanserver.application.service
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import notbe.tmtm.ddanddanserver.domain.model.pet.PetType
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.StatsAdminRepository
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.StatsDailyCount
+import notbe.tmtm.ddanddanserver.infrastructure.database.repository.StatsPetTypeCount
+import java.time.LocalDate
+
+class StatsAdminServiceTest : FunSpec({
+    lateinit var repository: StatsAdminRepository
+    lateinit var service: StatsAdminService
+
+    beforeEach {
+        repository = mockk()
+        service = StatsAdminService(repository)
+    }
+
+    test("getDashboard는 repository 호출 결과를 그대로 응답에 매핑한다") {
+        every { repository.countAllUsers() } returns 1284L
+        every { repository.countAllPets() } returns 956L
+        every { repository.countNewUsersBetween(any(), any()) } returnsMany
+            listOf(17L, 142L, 612L)
+        every { repository.countDistinctActiveUsersBetween(any(), any()) } returnsMany
+            listOf(412L, 893L)
+        every { repository.groupPetsByType() } returns
+            listOf(
+                StatsPetTypeCount(PetType.CAT, 312),
+                StatsPetTypeCount(PetType.DOG, 280),
+                StatsPetTypeCount(PetType.HAMSTER, 200),
+            )
+        every { repository.getSignupSeries(any(), any()) } returns
+            listOf(
+                StatsDailyCount("2026-04-22", 17),
+                StatsDailyCount("2026-04-23", 22),
+            )
+
+        val result = service.getDashboard(seriesDays = 14)
+
+        result.totalUsers shouldBe 1284L
+        result.totalPets shouldBe 956L
+        result.newUsersToday shouldBe 17L
+        result.newUsersThisWeek shouldBe 142L
+        result.newUsersThisMonth shouldBe 612L
+        result.activeUsersToday shouldBe 412L
+        result.activeUsersThisWeek shouldBe 893L
+        result.petDistribution shouldHaveSize 3
+        result.petDistribution[0].type shouldBe PetType.CAT
+        result.petDistribution[0].count shouldBe 312L
+        result.signupSeries.map { it.date } shouldContainExactly listOf("2026-04-22", "2026-04-23")
+    }
+
+    test("today 호출은 from=to=오늘로 일치한다") {
+        every { repository.countAllUsers() } returns 0L
+        every { repository.countAllPets() } returns 0L
+        every { repository.countDistinctActiveUsersBetween(any(), any()) } returns 0L
+        every { repository.groupPetsByType() } returns emptyList()
+        every { repository.getSignupSeries(any(), any()) } returns emptyList()
+
+        val fromCaptors = mutableListOf<LocalDate>()
+        val toCaptors = mutableListOf<LocalDate>()
+        every { repository.countNewUsersBetween(capture(fromCaptors), capture(toCaptors)) } returns 0L
+
+        service.getDashboard(seriesDays = 14)
+
+        // 첫 번째 호출이 오늘(today, today)
+        fromCaptors[0] shouldBe toCaptors[0]
+        // 두 번째 호출이 7일 (오늘 포함, weekAgo = today-6)
+        toCaptors[1] shouldBe fromCaptors[0]
+        java.time.temporal.ChronoUnit.DAYS.between(fromCaptors[1], toCaptors[1]) shouldBe 6L
+        // 세 번째 호출이 30일 (오늘 포함, monthAgo = today-29)
+        java.time.temporal.ChronoUnit.DAYS.between(fromCaptors[2], toCaptors[2]) shouldBe 29L
+    }
+
+    test("seriesDays=N이면 시리즈 시작일은 오늘에서 N-1일 전") {
+        every { repository.countAllUsers() } returns 0L
+        every { repository.countAllPets() } returns 0L
+        every { repository.countNewUsersBetween(any(), any()) } returns 0L
+        every { repository.countDistinctActiveUsersBetween(any(), any()) } returns 0L
+        every { repository.groupPetsByType() } returns emptyList()
+
+        val seriesFromSlot = slot<LocalDate>()
+        val seriesToSlot = slot<LocalDate>()
+        every { repository.getSignupSeries(capture(seriesFromSlot), capture(seriesToSlot)) } returns emptyList()
+
+        service.getDashboard(seriesDays = 30)
+
+        java.time.temporal.ChronoUnit.DAYS.between(seriesFromSlot.captured, seriesToSlot.captured) shouldBe 29L
+    }
+
+    test("petDistribution과 signupSeries는 repository의 순서를 보존한다") {
+        every { repository.countAllUsers() } returns 0L
+        every { repository.countAllPets() } returns 0L
+        every { repository.countNewUsersBetween(any(), any()) } returns 0L
+        every { repository.countDistinctActiveUsersBetween(any(), any()) } returns 0L
+        every { repository.groupPetsByType() } returns
+            listOf(
+                StatsPetTypeCount(PetType.PENGUIN, 100),
+                StatsPetTypeCount(PetType.MOLE, 50),
+            )
+        every { repository.getSignupSeries(any(), any()) } returns
+            listOf(
+                StatsDailyCount("2026-04-22", 0),
+                StatsDailyCount("2026-04-23", 5),
+                StatsDailyCount("2026-04-24", 0),
+            )
+
+        val result = service.getDashboard(seriesDays = 3)
+
+        result.petDistribution.map { it.type } shouldContainExactly listOf(PetType.PENGUIN, PetType.MOLE)
+        result.signupSeries.map { it.count } shouldContainExactly listOf(0L, 5L, 0L)
+
+        verify(exactly = 1) { repository.groupPetsByType() }
+        verify(exactly = 1) { repository.getSignupSeries(any(), any()) }
+    }
+})


### PR DESCRIPTION
## 작업 내용
- \`GET /v1/admin/stats/dashboard?seriesDays=14\` 신설 (default 14, max 90)
- \`StatsAdminController + Service + custom Repository (Impl)\`
- DTO: \`StatsAdminResponse\` / \`PetCountResponse\` / \`DailyCountResponse\`
- KST 기준 시간 처리, ObjectId timestamp range로 가입 통계 산출
- \`UserStatRepositoryImpl\`과 동일 패턴으로 \`MongoTemplate.aggregate\` 사용

## 응답 shape
\`\`\`json
{
  "totalUsers": 1284,
  "newUsersToday": 17, "newUsersThisWeek": 142, "newUsersThisMonth": 612,
  "activeUsersToday": 412, "activeUsersThisWeek": 893,
  "totalPets": 956,
  "petDistribution": [{"type":"CAT","count":312}, ...],
  "signupSeries": [{"date":"2026-04-22","count":17}, ...]
}
\`\`\`

## 영향 범위
- 신규 endpoint만 추가. 기존 동작 변경 없음.
- 인증: \`/v1/admin/**\`이라 \`AdminJWTAuthFilter\` 자동 적용.

## 테스트 / 확인 방법
- [x] \`StatsAdminServiceTest\` 단위 4건 통과
- [x] compileKotlin / compileTestKotlin 통과

## 관련 이슈
Closes #299

## admin 측 후속
\`ddan-ddan-admin\`은 schema/api/UI를 함께 push 예정 (mock 우선 동작, server 머지 후 real 자동 전환).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * OAuth(Kakao/Apple) 신규 가입 시 운영팀 Discord 채널로 자동 알림 발송
  * 관리자용 통계 대시보드 추가 (전체 사용자/펫 수, 신규/활성 사용자, 펫 종류별 분포, 가입 추이)

* **문서화**
  * 아키텍처 분석, 설계 문서 및 구현·테스트·리뷰 문서 추가 (알림 행위, 환경 설정, 위험요인 및 미해결 질문 포함)

* **테스트**
  * 관리자 통계 및 이벤트 흐름 관련 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->