### PR TITLE
fix: 일반 사용자 로그인 401 회귀 (FilterChain Order)

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/config/WebSecurityConfig.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/config/WebSecurityConfig.kt
@@ -75,7 +75,7 @@ class WebSecurityConfig(
     }
 
     @Bean
-    @Order(1)
+    @Order(2)
     fun apiFilterChain(
         http: HttpSecurity,
         jwtTokenProvider: JWTTokenProvider,
@@ -104,7 +104,7 @@ class WebSecurityConfig(
             }.build()
 
     @Bean
-    @Order(2)
+    @Order(1)
     fun loginFilterChain(httpSecurity: HttpSecurity): SecurityFilterChain =
         httpSecurity
             .securityMatcher("/v1/auth/**", "/swagger-ui/index.html")


### PR DESCRIPTION
## 🔎 작업 내용

운영 핫픽스 — 일반 사용자(Kakao/Apple OAuth) 로그인이 401로 차단되는 회귀 수정.

### 원인
PR #291(어드민 API)에서 SecurityFilterChain Order 재배치 시 \`loginFilterChain\`을 0 → 2로 옮김. 결과:

| Chain | Order | securityMatcher |
|---|---|---|
| adminFilterChain | 0 | \`/v1/admin/**\` |
| **apiFilterChain** | **1** | **\`/v1/**\`** ← \`/v1/auth/**\`도 매치 |
| loginFilterChain | 2 | \`/v1/auth/**\`, \`/swagger-ui/...\` |

Spring Security는 Order 순서로 평가하고 첫 매치 chain만 적용 → \`/v1/auth/login\`이 apiFilterChain(Order=1)에 먼저 매치되어 \`anyRequest().authenticated()\` 적용 → 401.

### 해결
- adminFilterChain: 0 (그대로)
- **loginFilterChain: 1** (apiFilterChain보다 우선)
- **apiFilterChain: 2**

### 검증
- dev `POST /v1/auth/login` → 401 재현 확인
- 핫픽스 적용 후 정상 200 + accessToken 발급 예정 (배포 후 검증)

close #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 보안 필터 처리 순서를 조정했습니다. 사용자에게 영향을 주지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->