### PR TITLE
chore: SecurityFilterChain Order 회귀 방지

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -43,6 +43,7 @@ tools: Read, Grep, Glob, Bash
 - 인증이 필요한 엔드포인트에 JWT 필터가 적용되는가
 - 민감 정보(토큰, PII) 로깅
 - 사용자 입력 검증
+- **SecurityFilterChain 변경 시 (Order, securityMatcher) 매트릭스 점검** — 새 chain 추가/Order 변경/매처 수정 시 모든 등록된 chain의 정합성을 표로 그려 확인. Spring Security는 **Order가 작은 chain이 우선** 매치되어 그 chain만 적용된다. 광범위 매처(`/v1/**`)는 좁은 매처(`/v1/auth/**`)보다 **Order가 더 커야** 한다. 이런 wiring 회귀는 단위 테스트로 못 잡으므로 핵심 경로에 최소한 reflection 기반 Order 단위 테스트(예: `WebSecurityConfigOrderTest`)가 있어야 한다. PR #302 참조.
 
 ### 5. PR 컨벤션
 - 변경 단위가 적절한가 (한 PR에 너무 많은 무관한 변경)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,3 +208,4 @@ EOF
 | 2026-05-02 | 초기 구성 | 전체 | - |
 | 2026-05-03 | Spring 어노테이션 핵심 코드 통합 테스트 가이드 추가 | skills/kotest-testing-patterns | PR #277 사고 — `@TransactionalEventListener`가 단일 MongoDB 환경에서 silent dropping. 단위 테스트가 listener 직접 호출이라 잡지 못함. |
 | 2026-05-03 | 체크리스트 보강 (통합 테스트 누락 + `@TransactionalEventListener` + 트랜잭션 매니저 페어 점검) | agents/code-reviewer | 동일 사고 재발 방지 |
+| 2026-05-06 | 체크리스트 보강 (SecurityFilterChain Order/securityMatcher 매트릭스 점검) | agents/code-reviewer | PR #302 사고 — apiFilterChain Order=1이 loginFilterChain Order=2보다 먼저 평가되어 `/v1/auth/login`이 401로 차단됨. 단위 테스트로 못 잡음. |

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/config/WebSecurityConfigOrderTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/config/WebSecurityConfigOrderTest.kt
@@ -1,0 +1,38 @@
+package notbe.tmtm.ddanddanserver.config
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import org.springframework.core.annotation.Order
+
+// SecurityFilterChain Order 매트릭스 회귀 방지 테스트.
+//
+// Spring Security는 등록된 SecurityFilterChain을 @Order 순서로 평가하고 첫 매치 chain만 적용한다.
+// 따라서 광범위한 securityMatcher (예: /v1/all)는 좁은 매처 (예: /v1/auth/all)보다 Order가 커야 한다.
+//
+// PR #302 사고: 어드민 작업 중 loginFilterChain Order가 0→2로 밀려 apiFilterChain(Order=1)이
+// /v1/auth/login에 먼저 매치되어 401로 차단됨. 단위 테스트로는 wiring 회귀를 못 잡으므로
+// reflection 기반으로 Order 매트릭스만이라도 강제한다.
+class WebSecurityConfigOrderTest : FunSpec({
+    val orders =
+        WebSecurityConfig::class
+            .java
+            .declaredMethods
+            .filter { it.returnType.simpleName == "SecurityFilterChain" }
+            .associate { method ->
+                method.name to (method.getAnnotation(Order::class.java)?.value ?: error("${method.name} has no @Order"))
+            }
+
+    test("adminFilterChain은 가장 작은 Order를 가진다") {
+        orders["adminFilterChain"]!! shouldBeLessThan orders["loginFilterChain"]!!
+        orders["adminFilterChain"]!! shouldBeLessThan orders["apiFilterChain"]!!
+    }
+
+    test("loginFilterChain은 apiFilterChain보다 Order가 작아야 한다 (좁은 /v1/auth 매처가 광범위 /v1 매처보다 먼저 매치되도록)") {
+        orders["loginFilterChain"]!! shouldBeLessThan orders["apiFilterChain"]!!
+    }
+
+    test("등록된 SecurityFilterChain이 정확히 3개여야 한다 (admin·login·api)") {
+        orders.keys shouldBe setOf("adminFilterChain", "loginFilterChain", "apiFilterChain")
+    }
+})


### PR DESCRIPTION
## 🔎 작업 내용

PR #302 회귀(loginFilterChain Order 변경으로 일반 로그인 401)의 재발 방지.

### 1) `code-reviewer.md` 체크리스트 보강
보안 영역에 SecurityFilterChain (Order, securityMatcher) 매트릭스 점검 항목 추가. 광범위 매처(`/v1/**`)는 좁은 매처(`/v1/auth/**`)보다 Order가 더 커야 함을 명시.

### 2) `WebSecurityConfigOrderTest` 단위 테스트
reflection으로 각 chain 메서드의 `@Order` 값을 읽어 매트릭스 검증:
- `adminFilterChain` < `loginFilterChain` < `apiFilterChain`
- 등록된 chain이 정확히 3개

누군가 Order를 잘못 변경하면 빌드 단계에서 즉시 실패 → 회귀 차단.

### 3) `CLAUDE.md` 변경 이력
2026-05-06 항목 추가.

close #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)