### PR TITLE
feat: 펫 카탈로그에 backgrounds(home/homeCompact/friendCard) 추가

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/PetCatalogService.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/service/PetCatalogService.kt
@@ -4,8 +4,10 @@ import notbe.tmtm.ddanddanserver.domain.exception.PetCatalogDuplicateKeyExceptio
 import notbe.tmtm.ddanddanserver.domain.exception.PetCatalogInactiveException
 import notbe.tmtm.ddanddanserver.domain.exception.PetCatalogNotFoundException
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalog
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogBackgrounds
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogItem
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogLevel
+import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogBackgroundsEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogLevelEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.PetCatalogRepository
@@ -51,6 +53,7 @@ class PetCatalogService(
     fun create(
         type: String,
         name: String,
+        backgrounds: PetCatalogBackgrounds,
         isActive: Boolean,
         displayOrder: Int,
         levels: Map<Int, PetCatalogLevel>,
@@ -62,6 +65,7 @@ class PetCatalogService(
                     PetCatalogEntity(
                         type = type,
                         name = name,
+                        backgrounds = PetCatalogBackgroundsEntity.fromDomain(backgrounds),
                         isActive = isActive,
                         displayOrder = displayOrder,
                         levels = levels.mapValues { PetCatalogLevelEntity.fromDomain(it.value) },
@@ -80,6 +84,7 @@ class PetCatalogService(
     fun update(
         type: String,
         name: String,
+        backgrounds: PetCatalogBackgrounds,
         isActive: Boolean,
         displayOrder: Int,
         levels: Map<Int, PetCatalogLevel>,
@@ -89,6 +94,7 @@ class PetCatalogService(
             repository.save(
                 existing.copy(
                     name = name,
+                    backgrounds = PetCatalogBackgroundsEntity.fromDomain(backgrounds),
                     isActive = isActive,
                     displayOrder = displayOrder,
                     levels = levels.mapValues { PetCatalogLevelEntity.fromDomain(it.value) },

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/petcatalog/PetCatalog.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/petcatalog/PetCatalog.kt
@@ -17,9 +17,9 @@ data class PetCatalogItem(
 )
 
 data class PetCatalogBackgrounds(
-    val home: String,
-    val homeCompact: String,
-    val friendCard: String,
+    val homeUrl: String,
+    val homeCompactUrl: String,
+    val friendCardUrl: String,
 )
 
 data class PetCatalogLevel(

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/petcatalog/PetCatalog.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/domain/model/petcatalog/PetCatalog.kt
@@ -10,9 +10,16 @@ data class PetCatalog(
 data class PetCatalogItem(
     val type: String,
     val name: String,
+    val backgrounds: PetCatalogBackgrounds,
     val isActive: Boolean,
     val displayOrder: Int,
     val levels: Map<Int, PetCatalogLevel>,
+)
+
+data class PetCatalogBackgrounds(
+    val home: String,
+    val homeCompact: String,
+    val friendCard: String,
 )
 
 data class PetCatalogLevel(

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/PetCatalogEntity.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/PetCatalogEntity.kt
@@ -1,6 +1,7 @@
 package notbe.tmtm.ddanddanserver.infrastructure.database.entity
 
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalog
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogBackgrounds
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogItem
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogLevel
 import org.bson.types.ObjectId
@@ -16,6 +17,7 @@ data class PetCatalogEntity(
     @Indexed(unique = true)
     val type: String,
     val name: String,
+    val backgrounds: PetCatalogBackgroundsEntity,
     val isActive: Boolean = true,
     val displayOrder: Int = 0,
     val levels: Map<Int, PetCatalogLevelEntity>,
@@ -26,6 +28,7 @@ data class PetCatalogEntity(
         PetCatalogItem(
             type = type,
             name = name,
+            backgrounds = backgrounds.toDomain(),
             isActive = isActive,
             displayOrder = displayOrder,
             levels = levels.mapValues { it.value.toDomain() },
@@ -36,9 +39,32 @@ data class PetCatalogEntity(
             PetCatalogEntity(
                 type = item.type,
                 name = item.name,
+                backgrounds = PetCatalogBackgroundsEntity.fromDomain(item.backgrounds),
                 isActive = item.isActive,
                 displayOrder = item.displayOrder,
                 levels = item.levels.mapValues { PetCatalogLevelEntity.fromDomain(it.value) },
+            )
+    }
+}
+
+data class PetCatalogBackgroundsEntity(
+    val home: String,
+    val homeCompact: String,
+    val friendCard: String,
+) {
+    fun toDomain(): PetCatalogBackgrounds =
+        PetCatalogBackgrounds(
+            home = home,
+            homeCompact = homeCompact,
+            friendCard = friendCard,
+        )
+
+    companion object {
+        fun fromDomain(backgrounds: PetCatalogBackgrounds): PetCatalogBackgroundsEntity =
+            PetCatalogBackgroundsEntity(
+                home = backgrounds.home,
+                homeCompact = backgrounds.homeCompact,
+                friendCard = backgrounds.friendCard,
             )
     }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/PetCatalogEntity.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/entity/PetCatalogEntity.kt
@@ -48,23 +48,23 @@ data class PetCatalogEntity(
 }
 
 data class PetCatalogBackgroundsEntity(
-    val home: String,
-    val homeCompact: String,
-    val friendCard: String,
+    val homeUrl: String,
+    val homeCompactUrl: String,
+    val friendCardUrl: String,
 ) {
     fun toDomain(): PetCatalogBackgrounds =
         PetCatalogBackgrounds(
-            home = home,
-            homeCompact = homeCompact,
-            friendCard = friendCard,
+            homeUrl = homeUrl,
+            homeCompactUrl = homeCompactUrl,
+            friendCardUrl = friendCardUrl,
         )
 
     companion object {
         fun fromDomain(backgrounds: PetCatalogBackgrounds): PetCatalogBackgroundsEntity =
             PetCatalogBackgroundsEntity(
-                home = backgrounds.home,
-                homeCompact = backgrounds.homeCompact,
-                friendCard = backgrounds.friendCard,
+                homeUrl = backgrounds.homeUrl,
+                homeCompactUrl = backgrounds.homeCompactUrl,
+                friendCardUrl = backgrounds.friendCardUrl,
             )
     }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/seed/PetCatalogSeeder.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/seed/PetCatalogSeeder.kt
@@ -2,6 +2,7 @@ package notbe.tmtm.ddanddanserver.infrastructure.database.seed
 
 import jakarta.annotation.PostConstruct
 import notbe.tmtm.ddanddanserver.common.util.logger
+import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogBackgroundsEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogLevelEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.PetCatalogRepository
@@ -22,6 +23,7 @@ class PetCatalogSeeder(
                 PetCatalogEntity(
                     type = pet.type,
                     name = pet.name,
+                    backgrounds = buildBackgrounds(pet.species),
                     isActive = true,
                     displayOrder = index,
                     levels = buildLevels(pet.species),
@@ -38,12 +40,19 @@ class PetCatalogSeeder(
         }
     }
 
+    private fun buildBackgrounds(species: String): PetCatalogBackgroundsEntity =
+        PetCatalogBackgroundsEntity(
+            home = "$CDN_BASE/$species/backgrounds/home.png?v=$INITIAL_VERSION",
+            homeCompact = "$CDN_BASE/$species/backgrounds/home_compact.png?v=$INITIAL_VERSION",
+            friendCard = "$CDN_BASE/$species/backgrounds/friend_card.png?v=$INITIAL_VERSION",
+        )
+
     private fun buildLevels(species: String): Map<Int, PetCatalogLevelEntity> =
         (1..MAX_LEVEL).associateWith { level ->
             PetCatalogLevelEntity(
-                imageUrl = "$CDN_BASE/$species/level$level.png",
-                lottieDefaultUrl = "$CDN_BASE/$species/level${level}_default.json",
-                lottiePlayEatUrl = "$CDN_BASE/$species/level${level}_play_eat.json",
+                imageUrl = "$CDN_BASE/$species/level$level.png?v=$INITIAL_VERSION",
+                lottieDefaultUrl = "$CDN_BASE/$species/level${level}_default.json?v=$INITIAL_VERSION",
+                lottiePlayEatUrl = "$CDN_BASE/$species/level${level}_play_eat.json?v=$INITIAL_VERSION",
             )
         }
 
@@ -56,6 +65,9 @@ class PetCatalogSeeder(
     companion object {
         private const val CDN_BASE = "https://ddan-ddan-cdn.ddmz.org"
         private const val MAX_LEVEL = 5
+
+        // 자산 캐시 무효화용 버전 쿼리. R2의 자산을 교체할 때마다 어드민에서 URL을 갱신해 v를 증분.
+        private const val INITIAL_VERSION = 1
         private val DEFAULT_PETS =
             listOf(
                 PetSeed(type = "CAT", name = "고양이", species = "cat"),

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/seed/PetCatalogSeeder.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/infrastructure/database/seed/PetCatalogSeeder.kt
@@ -42,17 +42,17 @@ class PetCatalogSeeder(
 
     private fun buildBackgrounds(species: String): PetCatalogBackgroundsEntity =
         PetCatalogBackgroundsEntity(
-            home = "$CDN_BASE/$species/backgrounds/home.png?v=$INITIAL_VERSION",
-            homeCompact = "$CDN_BASE/$species/backgrounds/home_compact.png?v=$INITIAL_VERSION",
-            friendCard = "$CDN_BASE/$species/backgrounds/friend_card.png?v=$INITIAL_VERSION",
+            homeUrl = "$CDN_BASE/$species/backgrounds/home.png",
+            homeCompactUrl = "$CDN_BASE/$species/backgrounds/home_compact.png",
+            friendCardUrl = "$CDN_BASE/$species/backgrounds/friend_card.png",
         )
 
     private fun buildLevels(species: String): Map<Int, PetCatalogLevelEntity> =
         (1..MAX_LEVEL).associateWith { level ->
             PetCatalogLevelEntity(
-                imageUrl = "$CDN_BASE/$species/level$level.png?v=$INITIAL_VERSION",
-                lottieDefaultUrl = "$CDN_BASE/$species/level${level}_default.json?v=$INITIAL_VERSION",
-                lottiePlayEatUrl = "$CDN_BASE/$species/level${level}_play_eat.json?v=$INITIAL_VERSION",
+                imageUrl = "$CDN_BASE/$species/level$level.png",
+                lottieDefaultUrl = "$CDN_BASE/$species/level${level}_default.json",
+                lottiePlayEatUrl = "$CDN_BASE/$species/level${level}_play_eat.json",
             )
         }
 
@@ -65,9 +65,6 @@ class PetCatalogSeeder(
     companion object {
         private const val CDN_BASE = "https://ddan-ddan-cdn.ddmz.org"
         private const val MAX_LEVEL = 5
-
-        // 자산 캐시 무효화용 버전 쿼리. R2의 자산을 교체할 때마다 어드민에서 URL을 갱신해 v를 증분.
-        private const val INITIAL_VERSION = 1
         private val DEFAULT_PETS =
             listOf(
                 PetSeed(type = "CAT", name = "고양이", species = "cat"),

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/PetCatalogAdminController.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/PetCatalogAdminController.kt
@@ -36,6 +36,7 @@ class PetCatalogAdminController(
             petCatalogService.create(
                 type = request.type,
                 name = request.name,
+                backgrounds = request.backgrounds.toDomain(),
                 isActive = request.isActive,
                 displayOrder = request.displayOrder,
                 levels = request.levelsToDomain(),
@@ -52,6 +53,7 @@ class PetCatalogAdminController(
             petCatalogService.update(
                 type = type,
                 name = request.name,
+                backgrounds = request.backgrounds.toDomain(),
                 isActive = request.isActive,
                 displayOrder = request.displayOrder,
                 levels = request.levelsToDomain(),

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/admin/PetCatalogAdminDto.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/admin/PetCatalogAdminDto.kt
@@ -4,6 +4,7 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogBackgrounds
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogItem
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogLevel
 
@@ -12,6 +13,8 @@ data class PetCatalogAdminCreateRequest(
     val type: String,
     @field:NotBlank
     val name: String,
+    @field:Valid
+    val backgrounds: PetCatalogBackgroundsRequest,
     val isActive: Boolean = true,
     @field:Min(0)
     val displayOrder: Int = 0,
@@ -25,6 +28,8 @@ data class PetCatalogAdminCreateRequest(
 data class PetCatalogAdminUpdateRequest(
     @field:NotBlank
     val name: String,
+    @field:Valid
+    val backgrounds: PetCatalogBackgroundsRequest,
     val isActive: Boolean,
     @field:Min(0)
     val displayOrder: Int,
@@ -33,6 +38,22 @@ data class PetCatalogAdminUpdateRequest(
     val levels: Map<Int, PetCatalogLevelRequest>,
 ) {
     fun levelsToDomain(): Map<Int, PetCatalogLevel> = levels.mapValues { it.value.toDomain() }
+}
+
+data class PetCatalogBackgroundsRequest(
+    @field:NotBlank
+    val home: String,
+    @field:NotBlank
+    val homeCompact: String,
+    @field:NotBlank
+    val friendCard: String,
+) {
+    fun toDomain(): PetCatalogBackgrounds =
+        PetCatalogBackgrounds(
+            home = home,
+            homeCompact = homeCompact,
+            friendCard = friendCard,
+        )
 }
 
 data class PetCatalogLevelRequest(
@@ -54,6 +75,7 @@ data class PetCatalogLevelRequest(
 data class PetCatalogAdminItemResponse(
     val type: String,
     val name: String,
+    val backgrounds: PetCatalogBackgroundsResponse,
     val isActive: Boolean,
     val displayOrder: Int,
     val levels: Map<Int, PetCatalogLevelResponse>,
@@ -63,9 +85,25 @@ data class PetCatalogAdminItemResponse(
             PetCatalogAdminItemResponse(
                 type = item.type,
                 name = item.name,
+                backgrounds = PetCatalogBackgroundsResponse.from(item.backgrounds),
                 isActive = item.isActive,
                 displayOrder = item.displayOrder,
                 levels = item.levels.mapValues { PetCatalogLevelResponse.from(it.value) },
+            )
+    }
+}
+
+data class PetCatalogBackgroundsResponse(
+    val home: String,
+    val homeCompact: String,
+    val friendCard: String,
+) {
+    companion object {
+        fun from(backgrounds: PetCatalogBackgrounds): PetCatalogBackgroundsResponse =
+            PetCatalogBackgroundsResponse(
+                home = backgrounds.home,
+                homeCompact = backgrounds.homeCompact,
+                friendCard = backgrounds.friendCard,
             )
     }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/admin/PetCatalogAdminDto.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/admin/PetCatalogAdminDto.kt
@@ -42,17 +42,17 @@ data class PetCatalogAdminUpdateRequest(
 
 data class PetCatalogBackgroundsRequest(
     @field:NotBlank
-    val home: String,
+    val homeUrl: String,
     @field:NotBlank
-    val homeCompact: String,
+    val homeCompactUrl: String,
     @field:NotBlank
-    val friendCard: String,
+    val friendCardUrl: String,
 ) {
     fun toDomain(): PetCatalogBackgrounds =
         PetCatalogBackgrounds(
-            home = home,
-            homeCompact = homeCompact,
-            friendCard = friendCard,
+            homeUrl = homeUrl,
+            homeCompactUrl = homeCompactUrl,
+            friendCardUrl = friendCardUrl,
         )
 }
 
@@ -94,16 +94,16 @@ data class PetCatalogAdminItemResponse(
 }
 
 data class PetCatalogBackgroundsResponse(
-    val home: String,
-    val homeCompact: String,
-    val friendCard: String,
+    val homeUrl: String,
+    val homeCompactUrl: String,
+    val friendCardUrl: String,
 ) {
     companion object {
         fun from(backgrounds: PetCatalogBackgrounds): PetCatalogBackgroundsResponse =
             PetCatalogBackgroundsResponse(
-                home = backgrounds.home,
-                homeCompact = backgrounds.homeCompact,
-                friendCard = backgrounds.friendCard,
+                homeUrl = backgrounds.homeUrl,
+                homeCompactUrl = backgrounds.homeCompactUrl,
+                friendCardUrl = backgrounds.friendCardUrl,
             )
     }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/PetCatalogResponse.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/PetCatalogResponse.kt
@@ -1,6 +1,7 @@
 package notbe.tmtm.ddanddanserver.presentation.dto.response
 
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalog
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogBackgrounds
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogItem
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogLevel
 
@@ -20,6 +21,7 @@ data class PetCatalogResponse(
 data class PetCatalogItemResponse(
     val type: String,
     val name: String,
+    val backgrounds: PetCatalogBackgroundsResponse,
     val isActive: Boolean,
     val displayOrder: Int,
     val levels: Map<Int, PetCatalogLevelResponse>,
@@ -29,9 +31,25 @@ data class PetCatalogItemResponse(
             PetCatalogItemResponse(
                 type = item.type,
                 name = item.name,
+                backgrounds = PetCatalogBackgroundsResponse.from(item.backgrounds),
                 isActive = item.isActive,
                 displayOrder = item.displayOrder,
                 levels = item.levels.mapValues { PetCatalogLevelResponse.from(it.value) },
+            )
+    }
+}
+
+data class PetCatalogBackgroundsResponse(
+    val home: String,
+    val homeCompact: String,
+    val friendCard: String,
+) {
+    companion object {
+        fun from(backgrounds: PetCatalogBackgrounds): PetCatalogBackgroundsResponse =
+            PetCatalogBackgroundsResponse(
+                home = backgrounds.home,
+                homeCompact = backgrounds.homeCompact,
+                friendCard = backgrounds.friendCard,
             )
     }
 }

--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/PetCatalogResponse.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/presentation/dto/response/PetCatalogResponse.kt
@@ -40,16 +40,16 @@ data class PetCatalogItemResponse(
 }
 
 data class PetCatalogBackgroundsResponse(
-    val home: String,
-    val homeCompact: String,
-    val friendCard: String,
+    val homeUrl: String,
+    val homeCompactUrl: String,
+    val friendCardUrl: String,
 ) {
     companion object {
         fun from(backgrounds: PetCatalogBackgrounds): PetCatalogBackgroundsResponse =
             PetCatalogBackgroundsResponse(
-                home = backgrounds.home,
-                homeCompact = backgrounds.homeCompact,
-                friendCard = backgrounds.friendCard,
+                homeUrl = backgrounds.homeUrl,
+                homeCompactUrl = backgrounds.homeCompactUrl,
+                friendCardUrl = backgrounds.friendCardUrl,
             )
     }
 }

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/PetCatalogServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/PetCatalogServiceTest.kt
@@ -32,9 +32,9 @@ class PetCatalogServiceTest : FunSpec({
             name = key,
             backgrounds =
                 PetCatalogBackgroundsEntity(
-                    home = "https://cdn/$key/backgrounds/home.png",
-                    homeCompact = "https://cdn/$key/backgrounds/home_compact.png",
-                    friendCard = "https://cdn/$key/backgrounds/friend_card.png",
+                    homeUrl = "https://cdn/$key/backgrounds/home.png",
+                    homeCompactUrl = "https://cdn/$key/backgrounds/home_compact.png",
+                    friendCardUrl = "https://cdn/$key/backgrounds/friend_card.png",
                 ),
             isActive = isActive,
             displayOrder = order,
@@ -145,9 +145,9 @@ class PetCatalogServiceTest : FunSpec({
 
     fun sampleBackgrounds(): PetCatalogBackgrounds =
         PetCatalogBackgrounds(
-            home = "https://cdn/x/backgrounds/home.png",
-            homeCompact = "https://cdn/x/backgrounds/home_compact.png",
-            friendCard = "https://cdn/x/backgrounds/friend_card.png",
+            homeUrl = "https://cdn/x/backgrounds/home.png",
+            homeCompactUrl = "https://cdn/x/backgrounds/home_compact.png",
+            friendCardUrl = "https://cdn/x/backgrounds/friend_card.png",
         )
 
     test("create는 신규 펫을 저장하고 versionCache를 invalidate한다") {

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/PetCatalogServiceTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/service/PetCatalogServiceTest.kt
@@ -9,7 +9,9 @@ import io.mockk.slot
 import io.mockk.verify
 import notbe.tmtm.ddanddanserver.domain.exception.PetCatalogDuplicateKeyException
 import notbe.tmtm.ddanddanserver.domain.exception.PetCatalogNotFoundException
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogBackgrounds
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogLevel
+import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogBackgroundsEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.entity.PetCatalogLevelEntity
 import notbe.tmtm.ddanddanserver.infrastructure.database.repository.PetCatalogRepository
@@ -28,6 +30,12 @@ class PetCatalogServiceTest : FunSpec({
         PetCatalogEntity(
             type = key,
             name = key,
+            backgrounds =
+                PetCatalogBackgroundsEntity(
+                    home = "https://cdn/$key/backgrounds/home.png",
+                    homeCompact = "https://cdn/$key/backgrounds/home_compact.png",
+                    friendCard = "https://cdn/$key/backgrounds/friend_card.png",
+                ),
             isActive = isActive,
             displayOrder = order,
             levels =
@@ -135,6 +143,13 @@ class PetCatalogServiceTest : FunSpec({
             ),
         )
 
+    fun sampleBackgrounds(): PetCatalogBackgrounds =
+        PetCatalogBackgrounds(
+            home = "https://cdn/x/backgrounds/home.png",
+            homeCompact = "https://cdn/x/backgrounds/home_compact.png",
+            friendCard = "https://cdn/x/backgrounds/friend_card.png",
+        )
+
     test("create는 신규 펫을 저장하고 versionCache를 invalidate한다") {
         // Given — cache를 미리 채움
         val initialVersion = Instant.parse("2026-05-01T00:00:00Z")
@@ -152,7 +167,7 @@ class PetCatalogServiceTest : FunSpec({
             )
         }
 
-        val result = service.create("QUOKKA", "쿼카", true, 5, sampleLevels())
+        val result = service.create("QUOKKA", "쿼카", sampleBackgrounds(), true, 5, sampleLevels())
 
         // Then — save + cache invalidate(다음 currentVersion이 새 값으로 조회)
         result.type shouldBe "QUOKKA"
@@ -167,7 +182,7 @@ class PetCatalogServiceTest : FunSpec({
         } throws org.springframework.dao.DuplicateKeyException("E11000 duplicate key error")
 
         shouldThrow<PetCatalogDuplicateKeyException> {
-            service.create("CAT", "고양이2", true, 0, sampleLevels())
+            service.create("CAT", "고양이2", sampleBackgrounds(), true, 0, sampleLevels())
         }
     }
 
@@ -182,6 +197,7 @@ class PetCatalogServiceTest : FunSpec({
             service.update(
                 type = "CAT",
                 name = "갱신된고양이",
+                backgrounds = sampleBackgrounds(),
                 isActive = false,
                 displayOrder = 99,
                 levels = sampleLevels(),
@@ -196,7 +212,7 @@ class PetCatalogServiceTest : FunSpec({
         every { repository.findByType("UNKNOWN") } returns null
 
         shouldThrow<PetCatalogNotFoundException> {
-            service.update("UNKNOWN", "x", true, 0, sampleLevels())
+            service.update("UNKNOWN", "x", sampleBackgrounds(), true, 0, sampleLevels())
         }
     }
 

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/PetCatalogControllerIntegrationTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/PetCatalogControllerIntegrationTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import notbe.tmtm.ddanddanserver.application.service.PetCatalogService
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalog
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogBackgrounds
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogItem
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogLevel
 import notbe.tmtm.ddanddanserver.presentation.filter.PetCatalogVersionFilter
@@ -60,6 +61,12 @@ class PetCatalogControllerIntegrationTest {
                         PetCatalogItem(
                             type = "CAT",
                             name = "고양이",
+                            backgrounds =
+                                PetCatalogBackgrounds(
+                                    home = "https://cdn/cat/backgrounds/home.png",
+                                    homeCompact = "https://cdn/cat/backgrounds/home_compact.png",
+                                    friendCard = "https://cdn/cat/backgrounds/friend_card.png",
+                                ),
                             isActive = true,
                             displayOrder = 0,
                             levels =

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/PetCatalogControllerIntegrationTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/PetCatalogControllerIntegrationTest.kt
@@ -63,9 +63,9 @@ class PetCatalogControllerIntegrationTest {
                             name = "고양이",
                             backgrounds =
                                 PetCatalogBackgrounds(
-                                    home = "https://cdn/cat/backgrounds/home.png",
-                                    homeCompact = "https://cdn/cat/backgrounds/home_compact.png",
-                                    friendCard = "https://cdn/cat/backgrounds/friend_card.png",
+                                    homeUrl = "https://cdn/cat/backgrounds/home.png",
+                                    homeCompactUrl = "https://cdn/cat/backgrounds/home_compact.png",
+                                    friendCardUrl = "https://cdn/cat/backgrounds/friend_card.png",
                                 ),
                             isActive = true,
                             displayOrder = 0,

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/PetCatalogAdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/PetCatalogAdminControllerIntegrationTest.kt
@@ -5,10 +5,12 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import notbe.tmtm.ddanddanserver.application.service.PetCatalogService
+import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogBackgrounds
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogItem
 import notbe.tmtm.ddanddanserver.domain.model.petcatalog.PetCatalogLevel
 import notbe.tmtm.ddanddanserver.presentation.dto.admin.PetCatalogAdminCreateRequest
 import notbe.tmtm.ddanddanserver.presentation.dto.admin.PetCatalogAdminUpdateRequest
+import notbe.tmtm.ddanddanserver.presentation.dto.admin.PetCatalogBackgroundsRequest
 import notbe.tmtm.ddanddanserver.presentation.dto.admin.PetCatalogLevelRequest
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -59,6 +61,12 @@ class PetCatalogAdminControllerIntegrationTest {
         PetCatalogItem(
             type = key,
             name = "이름-$key",
+            backgrounds =
+                PetCatalogBackgrounds(
+                    home = "https://cdn/x/backgrounds/home.png?v=1",
+                    homeCompact = "https://cdn/x/backgrounds/home_compact.png?v=1",
+                    friendCard = "https://cdn/x/backgrounds/friend_card.png?v=1",
+                ),
             isActive = isActive,
             displayOrder = order,
             levels =
@@ -72,6 +80,13 @@ class PetCatalogAdminControllerIntegrationTest {
                 ),
         )
 
+    private fun sampleBackgroundsRequest(): PetCatalogBackgroundsRequest =
+        PetCatalogBackgroundsRequest(
+            home = "u/backgrounds/home.png?v=1",
+            homeCompact = "u/backgrounds/home_compact.png?v=1",
+            friendCard = "u/backgrounds/friend_card.png?v=1",
+        )
+
     @Test
     fun `GET v1 admin pet-catalog는 비활성 포함 전체를 반환한다`() {
         every { petCatalogService.getAllForAdmin() } returns
@@ -82,17 +97,19 @@ class PetCatalogAdminControllerIntegrationTest {
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.pets[0].type").value("CAT"))
             .andExpect(jsonPath("$.pets[0].isActive").value(true))
+            .andExpect(jsonPath("$.pets[0].backgrounds.home").value("https://cdn/x/backgrounds/home.png?v=1"))
             .andExpect(jsonPath("$.pets[1].type").value("HIDDEN"))
             .andExpect(jsonPath("$.pets[1].isActive").value(false))
     }
 
     @Test
     fun `POST v1 admin pet-catalog는 신규 펫을 등록한다`() {
-        every { petCatalogService.create(any(), any(), any(), any(), any()) } returns item("QUOKKA", 5)
+        every { petCatalogService.create(any(), any(), any(), any(), any(), any()) } returns item("QUOKKA", 5)
         val request =
             PetCatalogAdminCreateRequest(
                 type = "QUOKKA",
                 name = "쿼카",
+                backgrounds = sampleBackgroundsRequest(),
                 isActive = true,
                 displayOrder = 5,
                 levels =
@@ -109,15 +126,16 @@ class PetCatalogAdminControllerIntegrationTest {
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.type").value("QUOKKA"))
 
-        verify { petCatalogService.create("QUOKKA", "쿼카", true, 5, any()) }
+        verify { petCatalogService.create("QUOKKA", "쿼카", any(), true, 5, any()) }
     }
 
     @Test
     fun `PUT v1 admin pet-catalog는 펫을 수정한다`() {
-        every { petCatalogService.update(any(), any(), any(), any(), any()) } returns item("CAT", 99, false)
+        every { petCatalogService.update(any(), any(), any(), any(), any(), any()) } returns item("CAT", 99, false)
         val request =
             PetCatalogAdminUpdateRequest(
                 name = "갱신",
+                backgrounds = sampleBackgroundsRequest(),
                 isActive = false,
                 displayOrder = 99,
                 levels = mapOf(1 to PetCatalogLevelRequest("a", "b", "c")),

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/PetCatalogAdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/presentation/controller/admin/PetCatalogAdminControllerIntegrationTest.kt
@@ -63,9 +63,9 @@ class PetCatalogAdminControllerIntegrationTest {
             name = "이름-$key",
             backgrounds =
                 PetCatalogBackgrounds(
-                    home = "https://cdn/x/backgrounds/home.png?v=1",
-                    homeCompact = "https://cdn/x/backgrounds/home_compact.png?v=1",
-                    friendCard = "https://cdn/x/backgrounds/friend_card.png?v=1",
+                    homeUrl = "https://cdn/x/backgrounds/home.png",
+                    homeCompactUrl = "https://cdn/x/backgrounds/home_compact.png",
+                    friendCardUrl = "https://cdn/x/backgrounds/friend_card.png",
                 ),
             isActive = isActive,
             displayOrder = order,
@@ -82,9 +82,9 @@ class PetCatalogAdminControllerIntegrationTest {
 
     private fun sampleBackgroundsRequest(): PetCatalogBackgroundsRequest =
         PetCatalogBackgroundsRequest(
-            home = "u/backgrounds/home.png?v=1",
-            homeCompact = "u/backgrounds/home_compact.png?v=1",
-            friendCard = "u/backgrounds/friend_card.png?v=1",
+            homeUrl = "u/backgrounds/home.png",
+            homeCompactUrl = "u/backgrounds/home_compact.png",
+            friendCardUrl = "u/backgrounds/friend_card.png",
         )
 
     @Test
@@ -97,7 +97,7 @@ class PetCatalogAdminControllerIntegrationTest {
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.pets[0].type").value("CAT"))
             .andExpect(jsonPath("$.pets[0].isActive").value(true))
-            .andExpect(jsonPath("$.pets[0].backgrounds.home").value("https://cdn/x/backgrounds/home.png?v=1"))
+            .andExpect(jsonPath("$.pets[0].backgrounds.homeUrl").value("https://cdn/x/backgrounds/home.png"))
             .andExpect(jsonPath("$.pets[1].type").value("HIDDEN"))
             .andExpect(jsonPath("$.pets[1].isActive").value(false))
     }


### PR DESCRIPTION
## 🔎 작업 내용

### 스키마 확장 — `PetCatalogItem.backgrounds` 추가

iOS 클라이언트는 펫별로 3종류의 배경 이미지를 사용 중 (`backgroundImage` / `seBackgroundImage` / `cardBackgroundImage`). 사용처 의미를 살려 `levels`처럼 한 뎁스 nested 객체로 노출. 필드명은 기존 `imageUrl`/`lottieDefaultUrl` 컨벤션과 통일해 `*Url` 접미사.

```kotlin
data class PetCatalogItem(
    val type: String,
    val name: String,
    val backgrounds: PetCatalogBackgrounds,   // ← 추가
    val isActive: Boolean,
    val displayOrder: Int,
    val levels: Map<Int, PetCatalogLevel>,
)

data class PetCatalogBackgrounds(
    val homeUrl: String,           // 홈 풀스크린 (iOS backgroundImage)
    val homeCompactUrl: String,    // 홈 소형 디바이스 (iOS seBackgroundImage)
    val friendCardUrl: String,     // 친구 카드 (iOS cardBackgroundImage)
)
```

### 변경된 wire

- `GET /v1/pets/catalog` 응답 `pets[].backgrounds.{homeUrl, homeCompactUrl, friendCardUrl}` 추가
- `POST /v1/admin/pet-catalog`, `PUT /v1/admin/pet-catalog/{type}` 요청 `backgrounds` 필수
- `GET /v1/admin/pet-catalog` 응답 `pets[].backgrounds` 추가

iOS는 아직 카탈로그를 소비하지 않아 wire 필드 추가 영향 없음. 어드민 프론트는 같이 수정 필요.

## ➕ 기타

- ./gradlew test 통과
- 캐시 무효화는 운영 컨벤션으로 — 자산 교체 시 어드민이 URL에 `?v=...` 추가하여 update API 호출
- 기존 5 docs(dev/prod) 마이그레이션 `\$set backgrounds` 별도 실행:
  ```js
  // species 매핑: CAT→cat, HAMSTER→hamster, PENGUIN→penguin, DOG→dog, MOLE→mole
  ```

close #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)