### PR TITLE
fix: dev 프로파일에서 신규 가입 Discord 알림 발송 건너뛰기

### DIFF
--- a/src/main/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListener.kt
+++ b/src/main/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListener.kt
@@ -21,6 +21,16 @@ class UserRegisteredEventListener(
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     fun handle(event: UserRegisteredEvent) {
+        // dev 프로파일은 실제 가입자 트래킹 대상이 아니라 테스트성 가입이 많아
+        // Discord 채널 노이즈가 크다. 운영 가시성은 prod 에만 필요하므로 dev 에서는 건너뛴다.
+        if (activeProfile.equals("dev", ignoreCase = true)) {
+            logger().info(
+                "Discord 신규 가입 알림 건너뜀 (dev 프로파일): userId={}, provider={}",
+                event.userId,
+                event.oAuthType,
+            )
+            return
+        }
         try {
             val count = userRepository.count()
             val phase = activeProfile.uppercase()

--- a/src/test/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListenerTest.kt
+++ b/src/test/kotlin/notbe/tmtm/ddanddanserver/application/event/UserRegisteredEventListenerTest.kt
@@ -65,7 +65,8 @@ class UserRegisteredEventListenerTest : FunSpec({
     }
 
     test("APPLE provider는 다른 이모지와 색상을 사용한다") {
-        listener = newListener(activeProfile = "dev")
+        // dev 는 발송이 건너뛰어지므로 local 프로파일로 검증 (이모지/색상은 프로파일과 무관)
+        listener = newListener(activeProfile = "local")
 
         val event =
             UserRegisteredEvent(
@@ -83,9 +84,43 @@ class UserRegisteredEventListenerTest : FunSpec({
         val embed = captured.captured.embeds!!.first()
         embed.title shouldBe "🍎 신규 가입"
         embed.color shouldBe 0x1C1C1E
-        embed.footer!!.text shouldBe "🧪 DEV · ddan-ddan-server"
+        embed.footer!!.text shouldBe "💻 LOCAL · ddan-ddan-server"
         embed.fields!!.find { it.name == "Provider" }!!.value shouldBe "APPLE"
         embed.fields.find { it.name == "누적 가입자" }!!.value shouldBe "7명"
+    }
+
+    test("dev 프로파일에서는 디스코드 웹훅을 발송하지 않는다") {
+        listener = newListener(activeProfile = "dev")
+
+        val event =
+            UserRegisteredEvent(
+                userId = ObjectId(),
+                nickName = "dev 테스트 가입",
+                oAuthType = OAuthType.KAKAO,
+                registeredAt = Instant.parse("2026-05-13T00:00:00Z"),
+            )
+
+        listener.handle(event)
+
+        // userRepository.count() 도 호출되지 않아야 한다 (불필요한 DB 조회 회피).
+        verify(exactly = 0) { userRepository.count() }
+        verify(exactly = 0) { discordHookApi.sendMessage(any()) }
+    }
+
+    test("dev 프로파일 매칭은 대소문자를 무시한다") {
+        listener = newListener(activeProfile = "DEV")
+
+        val event =
+            UserRegisteredEvent(
+                userId = ObjectId(),
+                nickName = "대문자 DEV",
+                oAuthType = OAuthType.KAKAO,
+                registeredAt = Instant.parse("2026-05-13T00:00:00Z"),
+            )
+
+        listener.handle(event)
+
+        verify(exactly = 0) { discordHookApi.sendMessage(any()) }
     }
 
     test("누적 가입자가 100 단위 마일스톤이면 description에 표시된다") {


### PR DESCRIPTION
## 🔎 작업 내용

- `UserRegisteredEventListener.handle()` 진입 직후 `activeProfile.equals("dev", ignoreCase = true)` 가드 추가. dev 프로파일이면 로그 한 줄 남기고 early return.
- 본문 진입을 차단하므로 `userRepository.count()` DB 조회도 함께 회피.
- `application-dev.yaml` 의 `spring.profiles.active=dev` 기반으로 동작 (`@Value("\${spring.profiles.active:local}")` 주입 그대로 활용).

## ➕ 기타

- **테스트**
  - 신규: `"dev 프로파일에서는 디스코드 웹훅을 발송하지 않는다"` — `userRepository.count()` / `discordHookApi.sendMessage` 둘 다 호출 0회 검증
  - 신규: `"dev 프로파일 매칭은 대소문자를 무시한다"` — `"DEV"` 입력 시도 차단 검증
  - 수정: `"APPLE provider는 다른 이모지와 색상을 사용한다"` — 기존 `activeProfile="dev"` 로 발송을 검증하던 케이스를 `"local"` 로 전환 (이모지/색상은 프로파일과 무관). 푸터 텍스트 assertion 도 `🧪 DEV` → `💻 LOCAL` 로 맞춤.
  - 통합 테스트(`UserRegisteredEventListenerIntegrationTest`)는 `spring.profiles.active=test` 사용으로 영향 없음.

- **회귀 위험**
  - prod 환경 발송 로직 변경 없음. `phase` 임베드 푸터 텍스트도 prod 에서 `🚀 PROD · ddan-ddan-server` 그대로.
  - dev 에서 발생하던 Discord 호출이 모두 사라지므로 dev 채널의 false-positive 알림 0건.

- **검증**
  - `./gradlew test --tests "...UserRegisteredEventListenerTest" --tests "...UserRegisteredEventListenerIntegrationTest"` BUILD SUCCESSFUL (JDK 17).

close

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 개발 환경에서 새 사용자 등록 Discord 알림이 비활성화됨 (대소문자 구분 없음)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ddan-dda-ra/ddan-ddan-server/pull/309)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->